### PR TITLE
chore: revert ci(test): adapt triggers to enable fork runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,5 @@
 name: test
-on:
-  push:
-    branches:
-      - dev
-      - patch-dev
-      - latest
-  pull_request:
-    branches:
-      - dev
+on: push
 jobs:
   report-to-slack-success:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts prisma/e2e-tests#671