### PR TITLE
chore: add telemetry info

### DIFF
--- a/databases/heroku-pgbouncer-buildpack/run.sh
+++ b/databases/heroku-pgbouncer-buildpack/run.sh
@@ -3,6 +3,7 @@
 set -eux
 
 sudo snap install heroku --classic
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases heroku-pgbouncer-buildpack build'
 yarn install
 yarn prisma generate
 

--- a/databases/heroku-pgbouncer/run.sh
+++ b/databases/heroku-pgbouncer/run.sh
@@ -2,5 +2,6 @@
 
 set -eu
 
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases heroku-pgbouncer build'
 yarn install
 yarn prisma generate

--- a/platforms/heroku/run.sh
+++ b/platforms/heroku/run.sh
@@ -3,6 +3,7 @@
 set -eux
 
 sudo snap install heroku --classic
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms heroku build'
 yarn install
 yarn prisma generate
 

--- a/platforms/netlify-beta-ci/package.json
+++ b/platforms/netlify-beta-ci/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "netlify dev",
-    "build": "prisma generate"
+    "build": "PRISMA_TELEMETRY_INFORMATION='e2e-tests platform netlify-ci build' && yarn prisma generate"
   },
   "dependencies": {
     "@prisma/client": "2.6.0-dev.59",

--- a/platforms/netlify-current-cli/run.sh
+++ b/platforms/netlify-current-cli/run.sh
@@ -3,6 +3,7 @@
 set -eu
 
 yarn install
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms netlify-cli build'
 yarn prisma generate
 
 sh build.sh

--- a/platforms/vercel-api/run.sh
+++ b/platforms/vercel-api/run.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-api build'
 yarn
 export VERCEL_PROJECT_ID=$VERCEL_API_PROJECT_ID
 export VERCEL_ORG_ID=$VERCEL_API_ORG_ID

--- a/platforms/vercel-node-builder/run.sh
+++ b/platforms/vercel-node-builder/run.sh
@@ -2,6 +2,7 @@
 
 set -eu
 
+export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-node-builder build'
 yarn
 export VERCEL_PROJECT_ID=$VERCEL_NODE_BUILDER_PROJECT_ID
 export VERCEL_ORG_ID=$VERCEL_NODE_BUILDER_ORG_ID


### PR DESCRIPTION
Apart from this PR, I also added the following from the UI of respective projects: 

|Project|PRISMA_TELEMETRY_INFORMATION|
|---|---|
| databases/heroku-pgbouncer-buildpack | e2e-tests databases heroku-pgbouncer-buildpack ci |
| databases/heroku-pgbouncer | e2e-tests databases heroku-pgbouncer ci |
| platforms/heroku | e2e-tests platforms heroku ci |
| platforms/netlify-beta-ci | e2e-tests platforms netlify-ci ci |
| platforms/netlify-current-cli | e2e-tests platforms netlify-cli ci |
| platforms/vercel-api | e2e-tests platforms vercel-api ci |
| platforms/vercel-node-builder | e2e-tests platforms vercel-node-builder ci |