### PR TITLE
ci(test-all): link to individual GitHub runs

### DIFF
--- a/.github/scripts/test-all.sh
+++ b/.github/scripts/test-all.sh
@@ -37,6 +37,7 @@ cd "$root"
 if [ "$GITHUB_REF" = "refs/heads/master" ] || [ "$GITHUB_REF" = "refs/heads/alpha" ]; then
 	(cd .github/slack/ && yarn install --silent)
 
+	run_url="$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/prisma/prisma2-e2e-tests/actions/runs/$GITHUB_RUN_ID/jobs | jq -j ".jobs[$((GITHUB_RUN_NUMBER - 1))].html_url")"
 	branch="${GITHUB_REF##*/}"
 	sha="$(git rev-parse HEAD | cut -c -7)"
 	short_sha="$(echo "$sha" | cut -c -7)"
@@ -52,12 +53,12 @@ if [ "$GITHUB_REF" = "refs/heads/master" ] || [ "$GITHUB_REF" = "refs/heads/alph
 	fi
 
 	echo "notifying slack channel"
-	node .github/slack/notify.js "$link: ${emoji} $project $matrix ran using prisma@$version"
+	node .github/slack/notify.js "$link: ${emoji} <$run_url|$project $matrix ran using prisma@$version>"
 
 	if [ $code -ne 0 ]; then
 		export webhook="$SLACK_WEBHOOK_URL_FAILING"
 		echo "notifying failing slack channel"
-		node .github/slack/notify.js "$link: :x: $project $matrix failed using prisma@$version"
+		node .github/slack/notify.js "$link: :x: <$run_url|$project $matrix failed using prisma@$version>"
 	fi
 fi
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: report success to slack
         run: sh .github/scripts/slack-workflow-status.sh ":white_check_mark:"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOWS }}
 
   report-to-slack-failure:
@@ -31,6 +32,7 @@ jobs:
       - name: report failure to slack
         run: sh .github/scripts/slack-workflow-status.sh ":x:"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOWS }}
 
   os:
@@ -49,6 +51,7 @@ jobs:
       - name: test on ${{ matrix.os }}
         run: sh .github/scripts/test-all.sh generic basic ${{ matrix.os }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
@@ -75,6 +78,7 @@ jobs:
       - name: test on node ${{ matrix.node }}
         run: sh .github/scripts/test-all.sh generic basic "node ${{ matrix.node }}"
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
@@ -101,6 +105,7 @@ jobs:
       - name: packager ${{ matrix.packager }}
         run: sh .github/scripts/test-all.sh packagers ${{ matrix.packager }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           PACKAGERS_NPM_PG_URL: ${{ secrets.PACKAGERS_NPM_PG_URL }}
@@ -129,6 +134,7 @@ jobs:
       - name: framework ${{ matrix.framework }}
         run: sh .github/scripts/test-all.sh frameworks ${{ matrix.framework }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           FRAMEWORK_NEXTJS_PG_URL: ${{ secrets.FRAMEWORK_NEXTJS_PG_URL }}
@@ -171,6 +177,7 @@ jobs:
       - name: test ${{ matrix.platform }}
         run: sh .github/scripts/test-all.sh platforms ${{ matrix.platform }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           CI: 1
@@ -228,6 +235,7 @@ jobs:
       - name: test ${{ matrix.bundler }}
         run: sh .github/scripts/test-all.sh bundlers ${{ matrix.bundler }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           WEBPACK_PG_URL: ${{ secrets.WEBPACK_PG_URL }}
@@ -257,6 +265,7 @@ jobs:
       - name: test ${{ matrix.library }}
         run: sh .github/scripts/test-all.sh libraries ${{ matrix.library }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           LIBRARY_EXPRESS_PG_URL: ${{ secrets.LIBRARY_EXPRESS_PG_URL }}
@@ -285,6 +294,7 @@ jobs:
       - name: test ${{ matrix.database }}
         run: sh .github/scripts/test-all.sh databases ${{ matrix.database }}
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
           DATABASE_DO_PG_BOUNCER_URL: ${{ secrets.DATABASE_DO_PG_BOUNCER_URL }}


### PR DESCRIPTION
Instead of linking to the workflow run, we want the actions to link to the exact job. This is just a draft of how we can access the GitHub API; unfortunately it turns out it's not possible to get individual check run IDs yet. Once it does, we may want to merge, but as long as it doesn't, we don't.

<img width="588" alt="image" src="https://user-images.githubusercontent.com/5013932/92487140-180e9580-f217-11ea-8e3d-f300a0025edc.png">
