### PR TITLE
fix: redwood version bump

### DIFF
--- a/platforms/vercel-with-redwood/api/package.json
+++ b/platforms/vercel-with-redwood/api/package.json
@@ -9,9 +9,5 @@
     "@prisma/client": "2.7.0-dev.43",
     "@redwoodjs/api": "0.18.0",
     "strip-ansi": "6.0.0"
-  },
-  "resolutions": {
-    "@prisma/cli": "2.7.0-dev.57",
-    "@prisma/client": "2.7.0-dev.57"
   }
 }

--- a/platforms/vercel-with-redwood/index.test.js
+++ b/platforms/vercel-with-redwood/index.test.js
@@ -11,7 +11,7 @@ test('should test prisma version', async () => {
     }
   `
   const data = await request(endpoint, query)
-  expect(data.prismaVersion).toEqual(pjson.resolutions['@prisma/client'])
+  expect(data.prismaVersion).toEqual(pjson.dependencies['@prisma/client'])
 })
 
 test('should query graphql users', async () => {


### PR DESCRIPTION
Continued from https://github.com/prisma/e2e-tests/pull/808