### PR TITLE
fix(redwood): add -W to yarn install

### DIFF
--- a/.github/scripts/check-for-update.sh
+++ b/.github/scripts/check-for-update.sh
@@ -4,7 +4,7 @@ set -eu
 shopt -s inherit_errexit || echo "shopt unsuccessful"
 
 cd .github/slack/
-yarn install
+yarn install -W
 cd ../..
 
 npm i -g json
@@ -113,7 +113,7 @@ while [ $i -le $count ]; do
           fi
 
           echo "$item: @prisma/cli expected $v, actual $vCLI"
-          yarn add "@prisma/cli@$v" --dev
+          yarn add "@prisma/cli@$v" --dev -W
         fi
 
         vPrismaClient="$(node -e "$pkg;console.log(pkg.dependencies['@prisma/client'])")"
@@ -124,7 +124,7 @@ while [ $i -le $count ]; do
           fi
 
           echo "$item: @prisma/client expected $v, actual $vPrismaClient"
-          yarn add "@prisma/client@$v"
+          yarn add "@prisma/client@$v" -W
         fi
       fi
     fi

--- a/platforms/vercel-with-redwood/run.sh
+++ b/platforms/vercel-with-redwood/run.sh
@@ -3,7 +3,7 @@
 set -eu
 
 export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-with-redwood build'
-yarn
+yarn -W
 export VERCEL_PROJECT_ID=$VERCEL_WITH_REDWOOD_PROJECT_ID
 export VERCEL_ORG_ID=$VERCEL_WITH_REDWOOD_ORG_ID
 echo "VERCEL_PROJECT_ID: $VERCEL_PROJECT_ID"


### PR DESCRIPTION
For reasons unknown, redwood test started to throw this error in the update script 

```
error Running this command will add the dependency to the workspace root rather than the workspace itself, which might not be what you want - if you really meant it, make it explicit by running this command again with the -W flag (or --ignore-workspace-root-check).
```

The fix is to add -W to the yarn add/install commands. But since we don't have an easy way to do it specifically to a project in `check-for-update.sh`, I added that generally (which shouldn't cause any issues)