### PR TITLE
chore: pin heroku node runtime

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -345,11 +345,11 @@ jobs:
         with:
           node-version: 12
 
-      - name: use node 14
+      - name: use node 12.18.4
         if: ${{ matrix.platform == 'heroku' }}
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 12.18.4
 
       - name: Install Puppeteer
         uses: ianwalter/puppeteer@v2.0.0
@@ -481,11 +481,11 @@ jobs:
         with:
           node-version: 12
 
-      - name: use node 14
+      - name: use node 12.18.4
         if: ${{ matrix.database == 'heroku-pgbouncer-buildpack' }}
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 12.18.4
 
       - name: test ${{ matrix.database }}
         id: run-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -340,9 +340,16 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: use node 12
+        if: ${{ matrix.platform != 'heroku' }}
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: use node 14
+        if: ${{ matrix.platform == 'heroku' }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - name: Install Puppeteer
         uses: ianwalter/puppeteer@v2.0.0
@@ -469,9 +476,16 @@ jobs:
         run: yarn install
 
       - name: use node 12
+        if: ${{ matrix.platform != 'heroku-pgbouncer-buildpack' }}
         uses: actions/setup-node@v1
         with:
           node-version: 12
+
+      - name: use node 14
+        if: ${{ matrix.platform == 'heroku-pgbouncer-buildpack' }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - name: test ${{ matrix.database }}
         id: run-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -476,13 +476,13 @@ jobs:
         run: yarn install
 
       - name: use node 12
-        if: ${{ matrix.platform != 'heroku-pgbouncer-buildpack' }}
+        if: ${{ matrix.database != 'heroku-pgbouncer-buildpack' }}
         uses: actions/setup-node@v1
         with:
           node-version: 12
 
       - name: use node 14
-        if: ${{ matrix.platform == 'heroku-pgbouncer-buildpack' }}
+        if: ${{ matrix.database == 'heroku-pgbouncer-buildpack' }}
         uses: actions/setup-node@v1
         with:
           node-version: 14

--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -5,7 +5,7 @@
   "author": "Divyendu Singh <singh@prisma.io>",
   "license": "MIT",
   "engines": {
-    "node": "14.x"
+    "node": "12.18.4"
   },
   "dependencies": {
     "@prisma/client": "2.9.0-dev.49",

--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -5,10 +5,10 @@
   "author": "Divyendu Singh <singh@prisma.io>",
   "license": "MIT",
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   },
   "dependencies": {
-    "@prisma/client": "2.7.0",
+    "@prisma/client": "2.9.0-dev.49",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },
@@ -16,6 +16,6 @@
     "start": "node index.js"
   },
   "devDependencies": {
-    "@prisma/cli": "2.7.0"
+    "@prisma/cli": "2.9.0-dev.49"
   }
 }

--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -4,6 +4,9 @@
   "main": "index.js",
   "author": "Divyendu Singh <singh@prisma.io>",
   "license": "MIT",
+  "engines": {
+    "node": "12.x"
+  },
   "dependencies": {
     "@prisma/client": "2.9.0-dev.49",
     "dotenv": "^8.2.0",

--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -8,7 +8,7 @@
     "node": "12.x"
   },
   "dependencies": {
-    "@prisma/client": "2.9.0-dev.49",
+    "@prisma/client": "2.8.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },
@@ -16,6 +16,6 @@
     "start": "node index.js"
   },
   "devDependencies": {
-    "@prisma/cli": "2.9.0-dev.49"
+    "@prisma/cli": "2.8.0"
   }
 }

--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -8,7 +8,7 @@
     "node": "12.x"
   },
   "dependencies": {
-    "@prisma/client": "2.8.0",
+    "@prisma/client": "2.7.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   },
@@ -16,6 +16,6 @@
     "start": "node index.js"
   },
   "devDependencies": {
-    "@prisma/cli": "2.8.0"
+    "@prisma/cli": "2.7.0"
   }
 }

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -7,14 +7,14 @@
     "node": "12.x"
   },
   "devDependencies": {
-    "@prisma/cli": "2.8.0",
+    "@prisma/cli": "2.7.0",
     "@types/node": "12.12.56"
   },
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
-    "@prisma/client": "2.8.0",
+    "@prisma/client": "2.7.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   }

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -7,14 +7,14 @@
     "node": "12.x"
   },
   "devDependencies": {
-    "@prisma/cli": "2.9.0-dev.49",
+    "@prisma/cli": "2.8.0",
     "@types/node": "12.12.56"
   },
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
-    "@prisma/client": "2.9.0-dev.49",
+    "@prisma/client": "2.8.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   }

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -4,17 +4,17 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   },
   "devDependencies": {
-    "@prisma/cli": "2.7.0",
+    "@prisma/cli": "2.9.0-dev.49",
     "@types/node": "12.12.56"
   },
   "scripts": {
     "start": "node index.js"
   },
   "dependencies": {
-    "@prisma/client": "2.7.0",
+    "@prisma/client": "2.9.0-dev.49",
     "dotenv": "^8.2.0",
     "express": "^4.17.1"
   }

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "node": "12.x"
+  },
   "devDependencies": {
     "@prisma/cli": "2.9.0-dev.49",
     "@types/node": "12.12.56"

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "engines": {
-    "node": "14.x"
+    "node": "12.18.4"
   },
   "devDependencies": {
     "@prisma/cli": "2.9.0-dev.49",


### PR DESCRIPTION
Reference: 

- https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

Related issue: https://github.com/prisma/prisma-client-js/issues/907

Node 12.19.0 is broken with Prisma, it was released on 6th October 2020 and Heroku is already using that version. This PR pins Heroku projects to node 12.18. 

I anticipate that other tools will also move to use that soon, so we should be ready. 