### PR TITLE
fix: vercel builder by changing scoped url

### DIFF
--- a/platforms/vercel-node-builder/finally.sh
+++ b/platforms/vercel-node-builder/finally.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-yarn vercel logs e2e-vercel-node-builder.vercel.app --token=$VERCEL_TOKEN --scope=prisma
+yarn vercel logs e2e-vercel-node-builder.prisma.vercel.app --token=$VERCEL_TOKEN --scope=prisma

--- a/platforms/vercel-node-builder/test.sh
+++ b/platforms/vercel-node-builder/test.sh
@@ -2,4 +2,4 @@
 
 set -eu
 
-npx ts-node ../../utils/fetch-retry.ts --url https://e2e-vercel-node-builder.vercel.app/ --prisma-version $(sh ../../utils/prisma_version.sh)
+npx ts-node ../../utils/fetch-retry.ts --url https://e2e-vercel-node-builder.prisma.vercel.app/ --prisma-version $(sh ../../utils/prisma_version.sh)


### PR DESCRIPTION
https://e2e-vercel-node-builder.vercel.app/ is not updating anymore, we made no changes to the test. 

Updating the URL to https://e2e-vercel-node-builder.prisma.vercel.app/ as a temporary workaround. 