### PR TITLE
chore: fix puppetter scoping condition

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -411,7 +411,7 @@ jobs:
           node-version: 12
 
       - name: Install Puppeteer
-        if: (${{ matrix.platform }} == 'codesandbox')
+        if: (matrix.platform == 'codesandbox')
         uses: ianwalter/puppeteer@v4.0.0
         with:
           args: yarn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -412,7 +412,7 @@ jobs:
           node-version: 12
 
       - name: Install Puppeteer
-        if: matrix.platform == 'codesandbox'
+        if: ${{ matrix.platform }} == 'codesandbox'
         uses: ianwalter/puppeteer@v4.0.0
         with:
           args: yarn

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -404,7 +404,8 @@ jobs:
       SERVERLESS_LAMBDA_PG_URL: ${{ secrets.SERVERLESS_LAMBDA_PG_URL }}
     steps:
       - uses: actions/checkout@v2
-
+      - name: Install Dependencies
+        run: yarn install
       - name: use node 12
         uses: actions/setup-node@v2-beta
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -411,7 +411,7 @@ jobs:
           node-version: 12
 
       - name: Install Puppeteer
-        if: (matrix.platform == 'codesandbox')
+        if: matrix.platform == 'codesandbox'
         uses: ianwalter/puppeteer@v4.0.0
         with:
           args: yarn


### PR DESCRIPTION
We only use `puppeteer` in `codesandbox` test so it should be installed only for that. This should increase the speed of all other platform tests. 