### PR TITLE
Create reproduction for webpack bundling runtime error

### DIFF
--- a/bundlers/webpack/webpack.config.js
+++ b/bundlers/webpack/webpack.config.js
@@ -1,6 +1,14 @@
-const nodeExternals = require('webpack-node-externals')
+// I will bundle node_modules
+// const nodeExternals = require('webpack-node-externals')
 
 module.exports = {
   target: 'node',
-  externals: [nodeExternals()],
+  
+  // I will bundle node_modules
+  // externals: [nodeExternals()],
+
+  // https://webpack.js.org/configuration/node/
+  // webpack patches __dirname which causes string_encoding/ to not be resolved
+  // uncomment to make that error go
+  // node: false
 }


### PR DESCRIPTION
Reproduction for https://github.com/prisma/prisma/issues/5250  and https://github.com/prisma/prisma/issues/2303

2 errors

Update this dependency to remove implicit peer dependency or add note to readme.
```
WARNING in ./node_modules/@prisma/client/runtime/index.js 10099:16-43
Module not found: Error: Can't resolve 'encoding' in '/Users/sid/Dev/prisma-source/bundlers/webpack/node_modules/@prisma/client/runtime'
 @ ./node_modules/.prisma/client/index.js 18:4-37
 @ ./node_modules/@prisma/client/index.js 1:15-40
 @ ./src/index.js 1:0-45 5:19-31
```

Add to readme to set `node` to `false` in webpack config. https://webpack.js.org/configuration/node/
```
ERROR in ./node_modules/@prisma/client/runtime/index.js 59534:24-64
Module not found: Error: Can't resolve 'string_decoder/' in '/Users/sid/Dev/prisma-source/bundlers/webpack/node_modules/@prisma/client/runtime'
 @ ./node_modules/.prisma/client/index.js 18:4-37
 @ ./node_modules/@prisma/client/index.js 1:15-40
 @ ./src/index.js 1:0-45 5:19-31
```

