### PR TITLE
chore: remove merge-confidence beta config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "github>whitesource/merge-confidence:beta"],
+  "extends": ["config:base"],
   "automerge": true,
   "automergeType": "branch",
   "major": {


### PR DESCRIPTION
## Changes

- Remove merge confidence beta opt-in config

## Context 

I don't think you need this opt-in anymore.
At least, not if you're using the GitHub hosted Renovate app.

Quote from https://github.com/whitesource/merge-confidence#enabling-and-disabling:
> Merge Confidence badges are enabled automatically for anyone using the WhiteSource Renovate App.