### PR TITLE
chore: masterIssue -> dependencyDashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "major": {
     "automerge": false
   },
-  "masterIssue": true,
+  "dependencyDashboard": true,
   "prConcurrentLimit": 25,
   "rebaseWhen": "conflicted",
   "ignoreDeps": [


### PR DESCRIPTION
## Changes

- Rename `masterIssue` to `dependencyDashboard`

## Context

Renovate has renamed the `masterIssue` feature to `dependencyDashboard`.
The functionality of your Dependency Dashboard will not change after you merge this PR.

See https://github.com/renovatebot/renovate/pull/6729

Link to relevant Renovate docs section: https://docs.renovatebot.com/presets-default/#dependencydashboard