### PR TITLE
chore: Group Redwood packages in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,11 @@
   "dependencyDashboard": true,
   "prConcurrentLimit": 25,
   "rebaseWhen": "conflicted",
-  "ignoreDeps": ["prisma", "@prisma/client"]
+  "ignoreDeps": ["prisma", "@prisma/client"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": "^@redwoodjs",
+      "groupName": ["@redwoodjs packages"]
+    }
+  ]
 }


### PR DESCRIPTION
to avoid https://github.com/prisma/e2e-tests/pull/1343 https://github.com/prisma/e2e-tests/pull/1344 https://github.com/prisma/e2e-tests/pull/1345 https://github.com/prisma/e2e-tests/pull/1346 https://github.com/prisma/e2e-tests/pull/1342

Docs: https://docs.renovatebot.com/faq/#group-all-packages-starting-with-abc-together-in-one-pr