### PR TITLE
chore: add renovate + dev2 config

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,11 @@
+const tempDirectory = require('temp-dir')
+
+module.exports = {
+  onboarding: true, // https://docs.renovatebot.com/self-hosted-configuration/#onboarding
+  cacheDir: tempDirectory,
+  token: process.env.GH_TOKEN,
+  repositories: ['prisma/e2e-tests'],
+  requireConfig: true,
+  forceCli: true,
+  force: true,
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "typescript": "4.1.3"
   },
   "scripts": {
-    "fetch-retry": "yarn ts-node utils/fetch-retry.ts"
+    "fetch-retry": "yarn ts-node utils/fetch-retry.ts",
+    "renovate:run": "renovate --automerge true --automerge-type pr --dependency-dashboard",
+    "renovate:debug": "yarn renovate:run --log-level debug"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "glob": "7.1.6",
     "graphql": "15.5.0",
     "node-fetch": "2.6.1",
+    "temp-dir": "2.0.0",
     "yaml": "2.0.0-3"
   },
   "devDependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,17 @@
   "prConcurrentLimit": 25,
   "rebaseWhen": "conflicted",
   "ignoreDeps": ["prisma", "@prisma/client"],
+  "baseBranches": ["dev", "dev2"],
   "packageRules": [
     {
       "matchPackagePatterns": "^@redwoodjs",
       "groupName": ["@redwoodjs packages"]
+    },
+    {
+      "matchBaseBranches": "dev2",
+      "packageNames": ["prisma", "@prisma/client"],
+      "enabled": true,
+      "followTag": "dev"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -156,6 +156,11 @@ source-map@^0.6.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+temp-dir@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
 ts-node@9.1.1:
   version "9.1.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"


### PR DESCRIPTION
We want to test if renovate CLI updates deps faster than our custom bash. 