### PR TITLE
ci: Reintegrate Codesandbox test into platforms block

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -413,15 +413,15 @@ jobs:
         with:
           node-version: 12
 
+      - name: Install Dependencies
+        run: yarn
+        
       # Install Puppeteer for Codesandbox test only
       - name: Install Puppeteer
-        if: matrix.platform == 'codesandbox'
+        if: ${{ matrix.platform == 'codesandbox' }}
         uses: ianwalter/puppeteer-container@v4.0.0
         with:
           args: yarn --ignore-engines
-
-      - name: Install Dependencies
-        run: yarn
 
       - name: test ${{ matrix.platform }}
         id: run-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -334,54 +334,6 @@ jobs:
         if: failure()
         run: bash .github/slack/notify-failure.sh frameworks ${{ matrix.framework }}
 
-  codesandbox:
-    needs: start-time
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - codesandbox
-
-    env:
-      START_TIME: ${{ needs.start-time.outputs.start-time }}
-      CI: 1
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
-      SSH_KEY_NETLIFY: ${{ secrets.SSH_KEY_NETLIFY }}
-      SSH_KEY_NETLIFY_ZISI: ${{ secrets.SSH_KEY_NETLIFY_ZISI }}
-      NPM_CONFIG_LOGLEVEL: error
-      NODE_ENV: development
-      NODE_MODULES_CACHE: false
-      NODE_VERBOSE: true
-      SERVERLESS_LAMBDA_PG_URL: ${{ secrets.SERVERLESS_LAMBDA_PG_URL }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: use node 12
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
-
-      - name: Install Puppeteer
-        uses: ianwalter/puppeteer-container@v4.0.0
-        with:
-          args: yarn --ignore-engines
-
-      - name: test ${{ matrix.platform }}
-        id: run-test
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 60
-          max_attempts: 3
-          command: bash .github/scripts/test-project.sh platforms ${{ matrix.platform }}
-
-      - name: notify-slack
-        if: failure()
-        run: bash .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
-
   platforms:
     needs: start-time
     runs-on: ubuntu-latest
@@ -405,6 +357,7 @@ jobs:
           - azure-functions-windows
           - aws-graviton
           - serverless-lambda
+          - codesandbox
 
     env:
       START_TIME: ${{ needs.start-time.outputs.start-time }}
@@ -459,6 +412,13 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12
+
+      # Install Puppeteer for Codesandbox test only
+      - name: Install Puppeteer
+        if: matrix.platform == 'codesandbox'
+        uses: ianwalter/puppeteer-container@v4.0.0
+        with:
+          args: yarn --ignore-engines
 
       - name: Install Dependencies
         run: yarn


### PR DESCRIPTION
Only install Puppeteer when the Matrix is running for Codesandbox, hence we can put them together again and have less jobs.

The missing check is expected, as this will be reconfigured on the repo after this has been merged.