### PR TITLE
fix(process-managers/pm2): Add -f to force restart on second or third try, double wait time

### DIFF
--- a/process-managers/pm2/run.sh
+++ b/process-managers/pm2/run.sh
@@ -5,5 +5,5 @@ set -eux
 yarn install
 yarn prisma generate
 
-yarn pm2 start --name prisma-pm2 --interpreter node "./server.js"
+yarn pm2 start --name prisma-pm2 --interpreter node "./server.js" -f
 sleep 5

--- a/process-managers/pm2/run.sh
+++ b/process-managers/pm2/run.sh
@@ -6,4 +6,4 @@ yarn install
 yarn prisma generate
 
 yarn pm2 start --name prisma-pm2 --interpreter node "./server.js" -f
-sleep 5
+sleep 10


### PR DESCRIPTION
Right now test is a bit flaky on macos, as sometimes it seems to not answer on the first try.
Example: https://github.com/prisma/e2e-tests/runs/1911696820?check_suite_focus=true

- Fix by adding -f to force a restart (and not fail when alread running on second or third try)
- Fix by doubling wait time before checking if server is up (5s to 10s)