### PR TITLE
fix(heroku): remove node engine requirement

### DIFF
--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -4,9 +4,6 @@
   "main": "index.js",
   "author": "Divyendu Singh <singh@prisma.io>",
   "license": "MIT",
-  "engines": {
-    "node": "12.x"
-  },
   "dependencies": {
     "@prisma/client": "2.18.0-dev.15",
     "dotenv": "^8.2.0",

--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
-  "engines": {
-    "node": "12.x"
-  },
   "devDependencies": {
     "@types/node": "12.20.1",
     "prisma": "2.18.0-dev.15"


### PR DESCRIPTION
Undoes leftover from previous workaround.

See for context: https://prisma-company.slack.com/archives/CRGDU19K6/p1613731541073000

closes #1459