### PR TITLE
chore: lambda - returns its error in bytes, so this reduces the math

### DIFF
--- a/platforms/lambda/zip.sh
+++ b/platforms/lambda/zip.sh
@@ -12,4 +12,4 @@ rm -rf node_modules/typescript
 
 zip -r lambda.zip index.js prisma/schema.prisma node_modules/.prisma node_modules/**
 
-du -h ./lambda.zip
+du -b ./lambda.zip


### PR DESCRIPTION
Makes it easier to debug issues like this:

```
Request must be smaller than 69905067 bytes for the UpdateFunctionCode operation
```