### PR TITLE
fix(platforms/serverless): use serverless CLI from Npm

### DIFF
--- a/platforms/serverless-lambda/README.md
+++ b/platforms/serverless-lambda/README.md
@@ -4,14 +4,6 @@ AWS Lambda using the serverless framework.
 
 ## How to run this locally
 
-### Install the serverless CLI
-
-```shell script
-curl -o- -L https://slss.io/install | bash
-```
-
-Fore more information, check [the official docs](https://serverless.com/framework/docs/getting-started/).
-
 ### Authenticate
 
 - `AWS_DEFAULT_REGION`: The AWS region name. In Prisma's case, this is `eu-central-1`.

--- a/platforms/serverless-lambda/prepare.sh
+++ b/platforms/serverless-lambda/prepare.sh
@@ -9,4 +9,5 @@ x="$AWS_ACCESS_KEY_ID"
 x="$AWS_SECRET_ACCESS_KEY"
 x="$AWS_ROLE"
 
+yarn install
 yarn serverless config credentials --provider aws --key "$AWS_ACCESS_KEY_ID" --secret "$AWS_SECRET_ACCESS_KEY"

--- a/platforms/serverless-lambda/prepare.sh
+++ b/platforms/serverless-lambda/prepare.sh
@@ -9,6 +9,4 @@ x="$AWS_ACCESS_KEY_ID"
 x="$AWS_SECRET_ACCESS_KEY"
 x="$AWS_ROLE"
 
-curl -o- -L https://slss.io/install | bash
-
-~/.serverless/bin/serverless config credentials --provider aws --key "$AWS_ACCESS_KEY_ID" --secret "$AWS_SECRET_ACCESS_KEY"
+yarn serverless config credentials --provider aws --key "$AWS_ACCESS_KEY_ID" --secret "$AWS_SECRET_ACCESS_KEY"

--- a/platforms/serverless-lambda/run.sh
+++ b/platforms/serverless-lambda/run.sh
@@ -8,4 +8,4 @@ yarn prisma generate
 
 yarn tsc
 
-~/.serverless/bin/serverless deploy --region "$AWS_DEFAULT_REGION"
+yarn serverless deploy --region "$AWS_DEFAULT_REGION"


### PR DESCRIPTION
No need for additional installation when CLI is already installed via Npm - just need to use it.