### PR TITLE
feat(platforms/lambda): measure lambda execution times

### DIFF
--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -53,7 +53,7 @@ export async function handler() {
     measurements: {
       outside_handler: Number(measure_client-measure_start) / 1000000000,
       inside_handler: Number(measure_end-measure_handler) / 1000000000,
-      total: Number(measure_end-measure_start) / 1000000000,
+      since_environment_start: Number(measure_end-measure_start) / 1000000000,
     }
   }
 }

--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -1,3 +1,4 @@
+const process = require('process');
 const measure_start = process.hrtime.bigint()
 
 import { PrismaClient, Prisma } from '@prisma/client'
@@ -57,15 +58,15 @@ export async function handler() {
     users,
     deleteManyUsers,
     measurements: {
-      client: measure_client-measure_start,
-      handler: measure_handler-measure_client,
-      delete_1: measure_delete_1-measure_handler,
-      create: measure_create-measure_delete_1,
-      update: measure_update-measure_create,
-      find: measure_find-measure_update,
-      delete_2: measure_delete_2-measure_find,
-      total_1: measure_delete_2-measure_start,
-      total_2: measure_delete_2-measure_handler
+      client: Number(measure_client-measure_start) / 1000000000,
+      handler: Number(measure_handler-measure_client) / 1000000000,
+      delete_1: Number(measure_delete_1-measure_handler) / 1000000000,
+      create: Number(measure_create-measure_delete_1) / 1000000000,
+      update:Number( measure_update-measure_create) / 1000000000,
+      find: Number(measure_find-measure_update) / 1000000000,
+      delete_2: Number(measure_delete_2-measure_find) / 1000000000,
+      total_1: Number(measure_delete_2-measure_start) / 1000000000,
+      total_2: Number(measure_delete_2-measure_handler) / 1000000000
     }
   }
 }

--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -58,6 +58,7 @@ export async function handler() {
       outside_handler: Number(measure_client-measure_start) / 1000000000,
       inside_handler: Number(measure_end-measure_handler) / 1000000000,
       inside_handler_connect: Number(measure_connect-measure_handler) / 1000000000,
+      inside_handler_queries: Number(measure_end-measure_connect) / 1000000000,
       since_environment_start: Number(measure_end-measure_start) / 1000000000,
     }
   }

--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -12,6 +12,10 @@ export async function handler() {
   
   const measure_handler = process.hrtime.bigint()
   
+  await client.$connect()
+
+  const measure_connect = process.hrtime.bigint()
+
   await client.user.deleteMany({})
   
   const id = '12345'
@@ -53,6 +57,7 @@ export async function handler() {
     measurements: {
       outside_handler: Number(measure_client-measure_start) / 1000000000,
       inside_handler: Number(measure_end-measure_handler) / 1000000000,
+      inside_handler_connect: Number(measure_connect-measure_handler) / 1000000000,
       since_environment_start: Number(measure_end-measure_start) / 1000000000,
     }
   }

--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -1,10 +1,19 @@
+const measure_start = process.hrtime.bigint()
+
 import { PrismaClient, Prisma } from '@prisma/client'
 
 const client = new PrismaClient()
 
+const measure_client = process.hrtime.bigint()
+    
 export async function handler() {
+  
+  const measure_handler = process.hrtime.bigint()
+  
   await client.user.deleteMany({})
 
+  const measure_delete_1 = process.hrtime.bigint()
+  
   const id = '12345'
 
   const createUser = await client.user.create({
@@ -15,6 +24,8 @@ export async function handler() {
     },
   })
 
+  const measure_create = process.hrtime.bigint()
+  
   const updateUser = await client.user.update({
     where: {
       id,
@@ -25,19 +36,36 @@ export async function handler() {
     },
   })
 
+  const measure_update = process.hrtime.bigint()
+  
   const users = await client.user.findUnique({
     where: {
       id,
     },
   })
 
+  const measure_find = process.hrtime.bigint()
+  
   const deleteManyUsers = await client.user.deleteMany({})
 
+  const measure_delete_2 = process.hrtime.bigint()
+  
   return {
     version: Prisma.prismaVersion.client,
     createUser,
     updateUser,
     users,
     deleteManyUsers,
+    measurements: {
+      client: measure_client-measure_start,
+      handler: measure_handler-measure_client,
+      delete_1: measure_delete_1-measure_handler,
+      create: measure_create-measure_delete_1,
+      update: measure_update-measure_create,
+      find: measure_find-measure_update,
+      delete_2: measure_delete_2-measure_find,
+      total_1: measure_delete_2-measure_start,
+      total_2: measure_delete_2-measure_handler
+    }
   }
 }

--- a/platforms/lambda/index.ts
+++ b/platforms/lambda/index.ts
@@ -1,4 +1,5 @@
 const process = require('process');
+
 const measure_start = process.hrtime.bigint()
 
 import { PrismaClient, Prisma } from '@prisma/client'
@@ -12,8 +13,6 @@ export async function handler() {
   const measure_handler = process.hrtime.bigint()
   
   await client.user.deleteMany({})
-
-  const measure_delete_1 = process.hrtime.bigint()
   
   const id = '12345'
 
@@ -24,8 +23,6 @@ export async function handler() {
       name: 'Alice',
     },
   })
-
-  const measure_create = process.hrtime.bigint()
   
   const updateUser = await client.user.update({
     where: {
@@ -36,20 +33,16 @@ export async function handler() {
       name: 'Bob',
     },
   })
-
-  const measure_update = process.hrtime.bigint()
   
   const users = await client.user.findUnique({
     where: {
       id,
     },
   })
-
-  const measure_find = process.hrtime.bigint()
   
   const deleteManyUsers = await client.user.deleteMany({})
 
-  const measure_delete_2 = process.hrtime.bigint()
+  const measure_end = process.hrtime.bigint()
   
   return {
     version: Prisma.prismaVersion.client,
@@ -58,15 +51,9 @@ export async function handler() {
     users,
     deleteManyUsers,
     measurements: {
-      client: Number(measure_client-measure_start) / 1000000000,
-      handler: Number(measure_handler-measure_client) / 1000000000,
-      delete_1: Number(measure_delete_1-measure_handler) / 1000000000,
-      create: Number(measure_create-measure_delete_1) / 1000000000,
-      update:Number( measure_update-measure_create) / 1000000000,
-      find: Number(measure_find-measure_update) / 1000000000,
-      delete_2: Number(measure_delete_2-measure_find) / 1000000000,
-      total_1: Number(measure_delete_2-measure_start) / 1000000000,
-      total_2: Number(measure_delete_2-measure_handler) / 1000000000
+      outside_handler: Number(measure_client-measure_start) / 1000000000,
+      inside_handler: Number(measure_end-measure_handler) / 1000000000,
+      total: Number(measure_end-measure_start) / 1000000000,
     }
   }
 }

--- a/platforms/lambda/test.ts
+++ b/platforms/lambda/test.ts
@@ -8,11 +8,12 @@ async function main() {
   const data = await invokeLambdaSync(name, '')
   console.log({ data: data.$response.data })
 
-  let actual = (data.$response.data as any).Payload  
+  let original = JSON.parse((data.$response.data as any).Payload)  
   console.log("original", actual)
-  delete actual.measurements
+  delete original.measurements
+  const actual = JSON.stringify(original)
   console.log("actual", actual)
-  
+
   const expect =
     '{"version":"' +
     Prisma.prismaVersion.client +

--- a/platforms/lambda/test.ts
+++ b/platforms/lambda/test.ts
@@ -9,7 +9,7 @@ async function main() {
   console.log({ data: data.$response.data })
 
   let original = JSON.parse((data.$response.data as any).Payload)  
-  console.log("original", actual)
+  console.log("original", original)
   delete original.measurements
   const actual = JSON.stringify(original)
   console.log("actual", actual)

--- a/platforms/lambda/test.ts
+++ b/platforms/lambda/test.ts
@@ -8,7 +8,10 @@ async function main() {
   const data = await invokeLambdaSync(name, '')
   console.log({ data: data.$response.data })
 
-  const actual = (data.$response.data as any).Payload
+  let actual = (data.$response.data as any).Payload  
+  console.log("original", actual)
+  delete actual.measurements
+  
   const expect =
     '{"version":"' +
     Prisma.prismaVersion.client +

--- a/platforms/lambda/test.ts
+++ b/platforms/lambda/test.ts
@@ -1,11 +1,16 @@
 import { Prisma } from '@prisma/client'
 import { invokeLambdaSync } from './utils'
+const process = require('process');
 
 const name = 'prisma2-e2e-tests'
 
 async function main() {
   console.log('testing function', name)
+  const measure_start = process.hrtime.bigint()
   const data = await invokeLambdaSync(name, '')
+  const measure_end = process.hrtime.bigint()
+  console.log('function invocation duration:', Number(measure_end-measure_start) / 1000000000)
+
   console.log({ data: data.$response.data })
 
   let original = JSON.parse((data.$response.data as any).Payload)  

--- a/platforms/lambda/test.ts
+++ b/platforms/lambda/test.ts
@@ -11,6 +11,7 @@ async function main() {
   let actual = (data.$response.data as any).Payload  
   console.log("original", actual)
   delete actual.measurements
+  console.log("actual", actual)
   
   const expect =
     '{"version":"' +


### PR DESCRIPTION
This PR adds measurements of both a) the time the execution of Lambda function takes in our tests, and b) the function itself about how long it takes to start, connect and query. The measurements are output in the log.

```
$ /home/runner/work/e2e-tests/e2e-tests/platforms/lambda/node_modules/.bin/ts-node test.ts
testing function prisma2-e2e-tests
function logs:
START RequestId: 780baab8-54f3-4e91-bb8b-7936613f03d4 Version: $LATEST
END RequestId: 780baab8-54f3-4e91-bb8b-7936613f03d4
REPORT RequestId: 780baab8-54f3-4e91-bb8b-7936613f03d4	Duration: 5262.18 ms	Billed Duration: 5263 ms	Memory Size: 128 MB	Max Memory Used: 122 MB	Init Duration: 380.85 ms	
XRAY TraceId: 1-605dbc0e-0a12f59838700d840275d1cc	SegmentId: 08026845304e5069	Sampled: true	

function invocation duration: 6.705887373
***
  data: ***
    StatusCode: 200,
    LogResult: 'U1RBUlQgUmVxdWVzdElkOiA3ODBiYWFiOC01NGYzLTRlOTEtYmI4Yi03OTM2NjEzZjAzZDQgVmVyc2lvbjogJExBVEVTVApFTkQgUmVxdWVzdElkOiA3ODBiYWFiOC01NGYzLTRlOTEtYmI4Yi03OTM2NjEzZjAzZDQKUkVQT1JUIFJlcXVlc3RJZDogNzgwYmFhYjgtNTRmMy00ZTkxLWJiOGItNzkzNjYxM2YwM2Q0CUR1cmF0aW9uOiA1MjYyLjE4IG1zCUJpbGxlZCBEdXJhdGlvbjogNTI2MyBtcwlNZW1vcnkgU2l6ZTogMTI4IE1CCU1heCBNZW1vcnkgVXNlZDogMTIyIE1CCUluaXQgRHVyYXRpb246IDM4MC44NSBtcwkKWFJBWSBUcmFjZUlkOiAxLTYwNWRiYzBlLTBhMTJmNTk4Mzg3MDBkODQwMjc1ZDFjYwlTZWdtZW50SWQ6IDA4MDI2ODQ1MzA0ZTUwNjkJU2FtcGxlZDogdHJ1ZQkK',
    ExecutedVersion: '$LATEST',
    Payload: '***"version":"2.20.0-dev.28","createUser":***"id":"12345","email":"alice@prisma.io","name":"Alice"***,"updateUser":***"id":"12345","email":"bob@prisma.io","name":"Bob"***,"users":***"id":"12345","email":"bob@prisma.io","name":"Bob"***,"deleteManyUsers":***"count":1***,"measurements":***"outside_handler":0.225459636,"inside_handler":5.25832124,"inside_handler_connect":4.255286439,"inside_handler_queries":1.003034801,"since_environment_start":5.4971756***'
  ***
***
```

Relevant bits:
```
function invocation duration: 6.705887373
```
and
```
"measurements": {
 "outside_handler":0.225459636,
 "inside_handler":5.25832124, 
 "inside_handler_connect":4.255286439,
 "inside_handler_queries":1.003034801,
 "since_environment_start":5.4971756
}
```
(This points to a cold start time of 1.2s by the way)