### PR TITLE
fix: Netlify CI example does not need env var and should not be tested via CLI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,10 @@
 name: lint test suite
-on: push
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'renovate.json'
   
 jobs:
   check-test-suite-coverage:

--- a/.github/workflows/optional-test.yaml
+++ b/.github/workflows/optional-test.yaml
@@ -1,5 +1,11 @@
 name: optional-test
-on: push
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'renovate.json'  
+
 env:
   PRISMA_TELEMETRY_INFORMATION: 'e2e-tests optional-test.yaml'
   SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_OPTIONAL_WORKFLOWS }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 name: test
-on: push
+
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'renovate.json'
+  
 env:
   PRISMA_TELEMETRY_INFORMATION: 'e2e-tests test.yaml'
   SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOWS }}

--- a/platforms-serverless/netlify-ci/README.md
+++ b/platforms-serverless/netlify-ci/README.md
@@ -1,14 +1,9 @@
 # Netlify CI
 
-Prisma and Netlify integration.
+Prisma and Netlify integration via Git (via another separate Git repository that is pushed to during deployment)
 
 ## How to run this locally
 
-### Netlify authentication
-
-A netlify token needs to be set with the environment variable `NETLIFY_AUTH_TOKEN`.
-
-Alternatively, you can login using `netlify login`.
 
 ### Environment variables
 
@@ -20,10 +15,4 @@ set up your own database and set the environment variable accordingly.
 
 ```shell script
 sh run.sh
-```
-
-Alternatively, you can also try deploying locally, but note that you might that the CI behaviour is not tested which might be relevant:
-
-```shell script
-netlify dev
 ```


### PR DESCRIPTION
Removes misleading mention of ENV var (which is not used here) and reference to CLI, which is not what we should be testing here.