### PR TITLE
fix(azure-functions): Clean infra setup, script, deployment size

### DIFF
--- a/platforms-serverless/azure-functions-linux/.funcignore
+++ b/platforms-serverless/azure-functions-linux/.funcignore
@@ -4,3 +4,7 @@
 .vscode
 local.settings.json
 test
+node_modules
+!node_modules/@prisma/client
+!node_modules/.prisma
+!node_modules/@azure/functions

--- a/platforms-serverless/azure-functions-linux/README.md
+++ b/platforms-serverless/azure-functions-linux/README.md
@@ -35,6 +35,10 @@ In CI, it uses our internal e2e test database using `platform-azure-functions-li
 Please check our internal 1Password E2E vault for a ready-to-use environment variable or  
 set up your own database and set the environment variable accordingly.
 
+### Prepare
+
+To create a function on your own account, run `sh create.sh` first.
+
 ### Run tests
 
 ```shell script

--- a/platforms-serverless/azure-functions-linux/create.sh
+++ b/platforms-serverless/azure-functions-linux/create.sh
@@ -7,9 +7,5 @@ group="prisma-e2e-linux"
 storage="e2estorageprismalinux"
 
 
-yarn install
-yarn prisma generate
-yarn tsc
-
 az group create --name "$group" --location westeurope
 az storage account create --name "$storage" --location westeurope --resource-group "$group" --sku Standard_LRS

--- a/platforms-serverless/azure-functions-linux/create.sh
+++ b/platforms-serverless/azure-functions-linux/create.sh
@@ -2,10 +2,8 @@
 
 set -eux
 
-app="prisma-e2e-linux-test-azure-functions-is-so-amazing"
 group="prisma-e2e-linux"
-storage="e2estorageprismalinux"
-
+storage="prismae2elinuxstorage" # only a-z0-9 in this string :(
 
 az group create --name "$group" --location westeurope
 az storage account create --name "$storage" --location westeurope --resource-group "$group" --sku Standard_LRS

--- a/platforms-serverless/azure-functions-linux/finally.sh
+++ b/platforms-serverless/azure-functions-linux/finally.sh
@@ -7,3 +7,4 @@ app="$(cat func-tmp.txt)"
 group="prisma-e2e-linux"
 
 az functionapp delete --name "$app" --resource-group "$group"
+az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-linux/finally.sh
+++ b/platforms-serverless/azure-functions-linux/finally.sh
@@ -7,4 +7,6 @@ app="$(cat func-tmp.txt)"
 group="prisma-e2e-linux"
 
 az functionapp delete --name "$app" --resource-group "$group"
+
+az config set extension.use_dynamic_install=yes_without_prompt
 az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -12,7 +12,7 @@ echo "$app" > func-tmp.txt
 cp -r "func-placeholder" "$app"
 
 group="prisma-e2e-linux"
-storage="e2estorageprismalinux"
+storage="prisma-e2e-linux-storage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Linux
 sleep 60

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -6,7 +6,7 @@ yarn install
 yarn prisma generate
 yarn tsc
 
-app="azure-function-linux-e2e-test-$(date "+%s")"
+app="azure-function-linux-e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$app" > func-tmp.txt
 
 cp -r "func-placeholder" "$app"

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -12,7 +12,7 @@ echo "$app" > func-tmp.txt
 cp -r "func-placeholder" "$app"
 
 group="prisma-e2e-linux"
-storage="prisma-e2e-linux-storage"
+storage="prismae2elinuxstorage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Linux
 sleep 60

--- a/platforms-serverless/azure-functions-linux/test.sh
+++ b/platforms-serverless/azure-functions-linux/test.sh
@@ -11,7 +11,8 @@ expected='{"version":"'$prisma_version'","createUser":{"id":"12345","email":"ali
 actual=$(curl "$url")
 
 if [ "$expected" != "$actual" ]; then
-  echo "expected '$expected', got '$actual'"
+  echo "expected '$expected'"
+  echo " but got '$actual'"
   exit 1
 fi
 

--- a/platforms-serverless/azure-functions-windows/.funcignore
+++ b/platforms-serverless/azure-functions-windows/.funcignore
@@ -4,3 +4,7 @@
 .vscode
 local.settings.json
 test
+node_modules
+!node_modules/@prisma/client
+!node_modules/.prisma
+!node_modules/@azure/functions

--- a/platforms-serverless/azure-functions-windows/README.md
+++ b/platforms-serverless/azure-functions-windows/README.md
@@ -35,6 +35,10 @@ In CI, it uses our internal e2e test database using `platform-azure-functions-li
 Please check our internal 1Password E2E vault for a ready-to-use environment variable or  
 set up your own database and set the environment variable accordingly.
 
+### Prepare
+
+To create a function on your own account, run `sh create.sh` first.
+
 ### Run tests
 
 ```shell script

--- a/platforms-serverless/azure-functions-windows/create.sh
+++ b/platforms-serverless/azure-functions-windows/create.sh
@@ -2,10 +2,8 @@
 
 set -eux
 
-app="prisma-e2e-windows-another-test"
-group="prisma-e2e-windows-new"
-# "windows" as storage name is illegal due to trademark x)
-storage="prismae2estoragewinnew"
+group="prisma-e2e-windows"
+storage="prismae2ewin6owsstorage" # "windows" as storage name is illegal due to trademark x) # only a-z0-9 in this string :(
 
 az group create --name "$group" --location westeurope
 az storage account create --name "$storage" --location westeurope --resource-group "$group" --sku Standard_LRS

--- a/platforms-serverless/azure-functions-windows/create.sh
+++ b/platforms-serverless/azure-functions-windows/create.sh
@@ -7,9 +7,5 @@ group="prisma-e2e-windows-new"
 # "windows" as storage name is illegal due to trademark x)
 storage="prismae2estoragewinnew"
 
-yarn install
-yarn prisma generate
-yarn tsc
-
 az group create --name "$group" --location westeurope
 az storage account create --name "$storage" --location westeurope --resource-group "$group" --sku Standard_LRS

--- a/platforms-serverless/azure-functions-windows/finally.sh
+++ b/platforms-serverless/azure-functions-windows/finally.sh
@@ -7,4 +7,6 @@ app="$(cat func-tmp.txt)"
 group="prisma-e2e-windows"
 
 az functionapp delete --name "$app" --resource-group "$group"
+
+az config set extension.use_dynamic_install=yes_without_prompt
 az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-windows/finally.sh
+++ b/platforms-serverless/azure-functions-windows/finally.sh
@@ -7,3 +7,4 @@ app="$(cat func-tmp.txt)"
 group="prisma-e2e-windows"
 
 az functionapp delete --name "$app" --resource-group "$group"
+az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-windows/finally.sh
+++ b/platforms-serverless/azure-functions-windows/finally.sh
@@ -4,6 +4,6 @@ set -eux
 
 app="$(cat func-tmp.txt)"
 
-group="prisma-e2e-windows-new"
+group="prisma-e2e-windows"
 
 az functionapp delete --name "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-windows/run.sh
+++ b/platforms-serverless/azure-functions-windows/run.sh
@@ -12,7 +12,7 @@ echo "$app" > func-tmp.txt
 cp -r "func-placeholder" "$app"
 
 group="prisma-e2e-windows"
-storage="prismae2ewin_owsstorage"
+storage="prismae2ewin6owsstorage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Windows
 sleep 60

--- a/platforms-serverless/azure-functions-windows/run.sh
+++ b/platforms-serverless/azure-functions-windows/run.sh
@@ -12,7 +12,7 @@ echo "$app" > func-tmp.txt
 cp -r "func-placeholder" "$app"
 
 group="prisma-e2e-windows"
-storage="prisma-e2e-win_ows-storage"
+storage="prismae2ewin_owsstorage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Windows
 sleep 60

--- a/platforms-serverless/azure-functions-windows/run.sh
+++ b/platforms-serverless/azure-functions-windows/run.sh
@@ -11,8 +11,8 @@ echo "$app" > func-tmp.txt
 
 cp -r "func-placeholder" "$app"
 
-group="prisma-e2e-windows-new"
-storage="prismae2estoragewinnew"
+group="prisma-e2e-windows"
+storage="prisma-e2e-win_ows-storage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Windows
 sleep 60

--- a/platforms-serverless/azure-functions-windows/run.sh
+++ b/platforms-serverless/azure-functions-windows/run.sh
@@ -6,7 +6,7 @@ yarn install
 yarn prisma generate
 yarn tsc
 
-app="azure-function-win-e2e-test-$(date "+%s")"
+app="azure-function-win-e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$app" > func-tmp.txt
 
 cp -r "func-placeholder" "$app"

--- a/platforms-serverless/azure-functions-windows/test.sh
+++ b/platforms-serverless/azure-functions-windows/test.sh
@@ -12,7 +12,8 @@ expected='{"version":"'$prisma_version'","createUser":{"id":"12345","email":"ali
 actual=$(curl "$url")
 
 if [ "$expected" != "$actual" ]; then
-  echo "expected '$expected', got '$actual'"
+  echo "expected '$expected'"
+  echo " but got '$actual'"
   exit 1
 fi
 

--- a/platforms-serverless/firebase-functions/run.sh
+++ b/platforms-serverless/firebase-functions/run.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-func="e2e_firebase_test_$(date "+%Y-%m-%d-%H%M%S")"
+func="e2e_firebase_test_$(date "+%Y_%m_%d_%H%M%S")" # note weird naming here
 echo "$func" > func-tmp.txt
 
 cd functions/ && sh prepare.sh "$func" && cd ..

--- a/platforms-serverless/firebase-functions/run.sh
+++ b/platforms-serverless/firebase-functions/run.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-func="e2e_firebase_test_$(date "+%s")"
+func="e2e_firebase_test_$(date "+%Y-%m-%d-%H%M%S")"
 echo "$func" > func-tmp.txt
 
 cd functions/ && sh prepare.sh "$func" && cd ..

--- a/platforms-serverless/gcp-functions/run.sh
+++ b/platforms-serverless/gcp-functions/run.sh
@@ -11,7 +11,7 @@ yarn prisma generate
 
 yarn tsc
 
-func="e2e-test-$(date "+%s")"
+func="e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$func" > func-tmp.txt
 
 gcloud functions deploy "$func" --runtime nodejs10 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars GCP_FUNCTIONS_PG_URL=$GCP_FUNCTIONS_PG_URL,PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms azure functions linux gcp functions env'


### PR DESCRIPTION
- new infra names for groups etc
- fixed cleanup script
- better naming of functions
- drastically lower size of deployed functions (341.36 MB -> 17.61 MB) and thus cold start times!