### PR TITLE
fix(azure): improve function creation logic

### DIFF
--- a/platforms-serverless/azure-functions-linux/finally.sh
+++ b/platforms-serverless/azure-functions-linux/finally.sh
@@ -6,7 +6,7 @@ app="$(cat func-tmp.txt)"
 
 group="prisma-e2e-linux"
 
-# az functionapp delete --name "$app" --resource-group "$group"
+az functionapp delete --name "$app" --resource-group "$group"
 
-# az config set extension.use_dynamic_install=yes_without_prompt
-# az monitor app-insights component delete --app "$app" --resource-group "$group"
+az config set extension.use_dynamic_install=yes_without_prompt
+az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-linux/finally.sh
+++ b/platforms-serverless/azure-functions-linux/finally.sh
@@ -6,7 +6,7 @@ app="$(cat func-tmp.txt)"
 
 group="prisma-e2e-linux"
 
-az functionapp delete --name "$app" --resource-group "$group"
+# az functionapp delete --name "$app" --resource-group "$group"
 
-az config set extension.use_dynamic_install=yes_without_prompt
-az monitor app-insights component delete --app "$app" --resource-group "$group"
+# az config set extension.use_dynamic_install=yes_without_prompt
+# az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -9,15 +9,16 @@ yarn tsc
 app="azure-function-linux-e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$app" > func-tmp.txt
 
+# TODO Do not copy, move it (otherwise we deploy both each time)
 cp -r "func-placeholder" "$app"
 
 group="prisma-e2e-linux"
 storage="prismae2elinuxstorage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Linux
-sleep 60
-yarn func azure functionapp publish "$app" --force
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "DEBUG=*"
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "AZURE_FUNCTIONS_LINUX_PG_URL=$AZURE_FUNCTIONS_LINUX_PG_URL"
+#sleep 60
+yarn func azure functionapp publish "$app" --force
 
-sleep 30
+#sleep 30

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -21,5 +21,3 @@ az functionapp config appsettings set --name "$app" --resource-group "$group" --
 
 sleep 30
 yarn func azure functionapp publish "$app" --force
-
-#sleep 30

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -9,8 +9,8 @@ yarn tsc
 app="azure-function-linux-e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$app" > func-tmp.txt
 
-# TODO Do not copy, move it (otherwise we deploy both each time)
-cp -r "func-placeholder" "$app"
+# give function folder our new app name
+mv "func-placeholder" "$app"
 
 group="prisma-e2e-linux"
 storage="prismae2elinuxstorage"

--- a/platforms-serverless/azure-functions-linux/run.sh
+++ b/platforms-serverless/azure-functions-linux/run.sh
@@ -18,7 +18,8 @@ storage="prismae2elinuxstorage"
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Linux
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "DEBUG=*"
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "AZURE_FUNCTIONS_LINUX_PG_URL=$AZURE_FUNCTIONS_LINUX_PG_URL"
-#sleep 60
+
+sleep 30
 yarn func azure functionapp publish "$app" --force
 
 #sleep 30

--- a/platforms-serverless/azure-functions-windows/finally.sh
+++ b/platforms-serverless/azure-functions-windows/finally.sh
@@ -6,7 +6,7 @@ app="$(cat func-tmp.txt)"
 
 group="prisma-e2e-windows"
 
-# az functionapp delete --name "$app" --resource-group "$group"
+az functionapp delete --name "$app" --resource-group "$group"
 
-# az config set extension.use_dynamic_install=yes_without_prompt
-# az monitor app-insights component delete --app "$app" --resource-group "$group"
+az config set extension.use_dynamic_install=yes_without_prompt
+az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-windows/finally.sh
+++ b/platforms-serverless/azure-functions-windows/finally.sh
@@ -6,7 +6,7 @@ app="$(cat func-tmp.txt)"
 
 group="prisma-e2e-windows"
 
-az functionapp delete --name "$app" --resource-group "$group"
+# az functionapp delete --name "$app" --resource-group "$group"
 
-az config set extension.use_dynamic_install=yes_without_prompt
-az monitor app-insights component delete --app "$app" --resource-group "$group"
+# az config set extension.use_dynamic_install=yes_without_prompt
+# az monitor app-insights component delete --app "$app" --resource-group "$group"

--- a/platforms-serverless/azure-functions-windows/run.sh
+++ b/platforms-serverless/azure-functions-windows/run.sh
@@ -9,15 +9,15 @@ yarn tsc
 app="azure-function-win-e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$app" > func-tmp.txt
 
-cp -r "func-placeholder" "$app"
+# give function folder our new app name
+mv "func-placeholder" "$app"
 
 group="prisma-e2e-windows"
 storage="prismae2ewin6owsstorage"
 
 az functionapp create --resource-group "$group" --consumption-plan-location westeurope --name "$app" --storage-account "$storage" --runtime "node" --os-type Windows
-sleep 60
-yarn func azure functionapp publish "$app" --force
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "DEBUG=*"
 az functionapp config appsettings set --name "$app" --resource-group "$group" --settings "AZURE_FUNCTIONS_WINDOWS_PG_URL=$AZURE_FUNCTIONS_WINDOWS_PG_URL"
 
 sleep 30
+yarn func azure functionapp publish "$app" --force


### PR DESCRIPTION
This cleans up the function creation logic to set the env vars directly after functionapp creation, and only waits before triggering the function upload. Also renamed the function template folder instead of copying so it only deploys 1 function each time, not 2.