### PR TITLE
chore: remove napi exclusions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -451,7 +451,7 @@ jobs:
         run: bash .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
 
   platforms-napi:
-    needs: [start-time, platforms-napi]
+    needs: [start-time, platforms] # Makes these tests run after their binary counterparts
     timeout-minutes: 60
 
     strategy:
@@ -594,7 +594,7 @@ jobs:
         run: bash .github/slack/notify-failure.sh platforms-serverless ${{ matrix.platform }}
 
   platforms-serverless-napi:
-    needs: [start-time, platforms-serverless]
+    needs: [start-time, platforms-serverless] # Makes these tests run after their binary counterparts
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
 
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -404,6 +404,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        engine: ['binary'] # see extracted napi below
         platform:
           - heroku
           - aws-graviton
@@ -511,6 +512,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        engine: ['binary'] # see extracted napi below
         platform:
           - lambda
           - vercel-node-builder

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -404,7 +404,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine: ['napi', 'binary']
         platform:
           - heroku
           - aws-graviton
@@ -424,9 +423,59 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Define Engine Type to test
-        if: ${{ matrix.engine == 'napi' }}
-        run: echo "PRISMA_FORCE_NAPI=true" >> $GITHUB_ENV
+      - name: use node 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+
+      - name: Install Dependencies
+        run: yarn
+
+      # Install Puppeteer for Codesandbox test only
+      - name: Install Puppeteer
+        if: ${{ matrix.platform == 'codesandbox' }}
+        uses: ianwalter/puppeteer-container@v4.0.0
+        with:
+          args: yarn --ignore-engines
+
+      - name: test ${{ matrix.platform }} - binary
+        id: run-test
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: bash .github/scripts/test-project.sh platforms ${{ matrix.platform }}
+
+      - name: notify-slack
+        if: failure()
+        run: bash .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
+
+  platforms-napi:
+    needs: start-time
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - heroku
+          - aws-graviton
+          - codesandbox
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    env:
+      START_TIME: ${{ needs.start-time.outputs.start-time }}
+      CI: 1
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
+      HEROKU_PG_URL: ${{ secrets.HEROKU_PG_URL }}
+      HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      SSH_KEY_GRAVITON: ${{ secrets.SSH_KEY_GRAVITON }}
+      PRISMA_FORCE_NAPI: true
+
+    steps:
+      - uses: actions/checkout@v2
 
       - name: use node 12
         uses: actions/setup-node@v2
@@ -443,7 +492,7 @@ jobs:
         with:
           args: yarn --ignore-engines
 
-      - name: test ${{ matrix.platform }} - ${{matrix.engine}}
+      - name: test ${{ matrix.platform }} - napi
         id: run-test
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,7 +77,7 @@ jobs:
 
   process-managers:
     needs: start-time
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -85,21 +85,21 @@ jobs:
         feature: [pm2]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-    
+
     env:
       START_TIME: ${{ needs.start-time.outputs.start-time }}
       CI: 1
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       PROCESS_MANAGER_PM2_PG_URL: ${{ secrets.PROCESS_MANAGER_PM2_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Define Engine Type to test
         if: ${{ matrix.engine == 'napi' }}
         run: echo "PRISMA_FORCE_NAPI=true" >> $GITHUB_ENV
-    
+
       - name: Install Dependencies
         run: yarn install
 
@@ -121,16 +121,13 @@ jobs:
 
   core-features:
     needs: start-time
-    
+
     strategy:
       fail-fast: false
       matrix:
         engine: ['napi', 'binary']
         feature: [auto-reconnect, browser-build, studio, napi-preview-feature]
         os: [ubuntu-latest] #, windows-latest, macos-latest]
-        exclude:
-        - engine: napi
-          feature: studio
     runs-on: ${{ matrix.os }}
 
     env:
@@ -139,7 +136,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -168,21 +165,21 @@ jobs:
 
   os:
     needs: start-time
-    
+
     strategy:
       fail-fast: false
       matrix:
         engine: ['napi', 'binary']
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    
+
     env:
       START_TIME: ${{ needs.start-time.outputs.start-time }}
       CI: 1
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -225,7 +222,7 @@ jobs:
           - 14.0.0 # minimal minor version of node 14 via https://www.prisma.io/docs/reference/system-requirements
           - 15
           - 16
-        os: [ubuntu-latest] #, windows-latest, macos-latest]    
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:
         - engine: napi
           node: 10.16.0
@@ -239,7 +236,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       OS_BASE_PG_URL: ${{ secrets.OS_BASE_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -266,7 +263,7 @@ jobs:
 
   binaries:
     needs: start-time
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -274,14 +271,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         binary: [pkg]
     runs-on: ${{ matrix.os }}
-    
+
     env:
       START_TIME: ${{ needs.start-time.outputs.start-time }}
       CI: 1
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       OS: ${{ matrix.os }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -318,7 +315,7 @@ jobs:
           - yarn
           - yarn-workspaces
           - yarn2-without-pnp
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -364,7 +361,7 @@ jobs:
         framework:
           - nestjs
           - nextjs
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -411,10 +408,7 @@ jobs:
           - heroku
           - aws-graviton
           - codesandbox
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
-        exclude:
-        - engine: napi
-          platform: aws-graviton
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -425,7 +419,7 @@ jobs:
       HEROKU_PG_URL: ${{ secrets.HEROKU_PG_URL }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       SSH_KEY_GRAVITON: ${{ secrets.SSH_KEY_GRAVITON }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -484,13 +478,9 @@ jobs:
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:
         - engine: napi
-          platform: azure-functions-linux
-        - engine: napi
           platform: azure-functions-windows
-        - engine: napi
-          platform: serverless-framework-lambda
     runs-on: ${{ matrix.os }}
-        
+
     env:
       START_TIME: ${{ needs.start-time.outputs.start-time }}
       CI: 1
@@ -534,7 +524,7 @@ jobs:
       FIREBASE_FUNCTIONS_PG_URL: ${{ secrets.FIREBASE_FUNCTIONS_PG_URL }}
       FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
       SERVERLESS_LAMBDA_PG_URL: ${{ secrets.SERVERLESS_LAMBDA_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -573,7 +563,7 @@ jobs:
           - webpack
           - parcel
           - rollup
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -584,7 +574,7 @@ jobs:
       WEBPACK_PG_URL: ${{ secrets.WEBPACK_PG_URL }}
       PARCEL_PG_URL: ${{ secrets.PARCEL_PG_URL }}
       ROLLUP_PG_URL: ${{ secrets.ROLLUP_PG_URL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -621,7 +611,7 @@ jobs:
           - apollo-server
           - type-graphql
           - nexus-schema
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -678,7 +668,7 @@ jobs:
           - supabase
           - supabase-pool
           - planetscale
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -743,7 +733,7 @@ jobs:
         engine: ['napi', 'binary']
         database:
           - sqlserver-azure-sql
-        os: [macos-latest] 
+        os: [macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -752,7 +742,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
       DATABASE_URL_DB_SQL_SERVER_AZURE_SQL: ${{ secrets.DATABASE_URL_DB_SQL_SERVER_AZURE_SQL }}
-    
+
     steps:
       - uses: actions/checkout@v2
 
@@ -789,7 +779,7 @@ jobs:
         engine: ['napi', 'binary']
         test-runner:
           - jest-with-multiple-generators
-        os: [ubuntu-latest] #, windows-latest, macos-latest] 
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -226,8 +226,6 @@ jobs:
         exclude:
         - engine: napi
           node: 10.16.0
-        - engine: napi
-          node: 12.2.0
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -451,7 +451,7 @@ jobs:
         run: bash .github/slack/notify-failure.sh platforms ${{ matrix.platform }}
 
   platforms-napi:
-    needs: start-time
+    needs: [start-time, platforms-napi]
     timeout-minutes: 60
 
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -461,7 +461,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine: ['napi', 'binary']
         platform:
           - lambda
           - vercel-node-builder
@@ -476,9 +475,6 @@ jobs:
           - azure-functions-windows
           - serverless-framework-lambda
         os: [ubuntu-latest] #, windows-latest, macos-latest]
-        exclude:
-        - engine: napi
-          platform: azure-functions-windows
     runs-on: ${{ matrix.os }}
 
     env:
@@ -527,10 +523,98 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: use node 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
 
-      - name: Define Engine Type to test
-        if: ${{ matrix.engine == 'napi' }}
-        run: echo "PRISMA_FORCE_NAPI=true" >> $GITHUB_ENV
+      - name: Install Dependencies
+        run: yarn
+
+      - name: test ${{ matrix.platform }} - binary
+        id: run-test
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          command: bash .github/scripts/test-project.sh platforms-serverless ${{ matrix.platform }}
+
+      - name: notify-slack
+        if: failure()
+        run: bash .github/slack/notify-failure.sh platforms-serverless ${{ matrix.platform }}
+
+  platforms-serverless-napi:
+    needs: [start-time, platforms-serverless]
+    timeout-minutes: 60 # can take longer if platforms are down, so better protect
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - lambda
+          - vercel-node-builder
+          - vercel-cli
+          - vercel-with-redwood
+          - vercel-with-nextjs
+          - netlify-cli
+          - netlify-ci
+          - gcp-functions
+          - firebase-functions
+          - azure-functions-linux
+          - azure-functions-windows
+          - serverless-framework-lambda
+        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        exclude:
+        - platform: azure-functions-windows
+    runs-on: ${{ matrix.os }}
+
+    env:
+      PRISMA_FORCE_NAPI: true
+      START_TIME: ${{ needs.start-time.outputs.start-time }}
+      CI: 1
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
+      SSH_KEY_NETLIFY: ${{ secrets.SSH_KEY_NETLIFY }}
+      SSH_KEY_NETLIFY_ZISI: ${{ secrets.SSH_KEY_NETLIFY_ZISI }}
+      GCP_FUNCTIONS_PG_URL: ${{ secrets.GCP_FUNCTIONS_PG_URL }}
+      GCP_FUNCTIONS_PROJECT: ${{ secrets.GCP_FUNCTIONS_PROJECT }}
+      GCP_FUNCTIONS_ACCOUNT: ${{ secrets.GCP_FUNCTIONS_ACCOUNT }}
+      GCP_FUNCTIONS_SECRET: ${{ secrets.GCP_FUNCTIONS_SECRET }}
+      NETLIFY_PG_URL: ${{ secrets.NETLIFY_PG_URL }}
+      NETLIFY_ZISI_PG_URL: ${{ secrets.NETLIFY_ZISI_PG_URL }}
+      LAMBDA_PG_URL: ${{ secrets.LAMBDA_PG_URL }}
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+      NPM_CONFIG_LOGLEVEL: error
+      NODE_ENV: development
+      NODE_MODULES_CACHE: false
+      NODE_VERBOSE: true
+      AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_ROLE: ${{ secrets.AWS_ROLE }}
+      VERCEL_NODE_BUILDER_PROJECT_ID: ${{ secrets.VERCEL_NODE_BUILDER_PROJECT_ID }}
+      VERCEL_NODE_BUILDER_ORG_ID: ${{ secrets.VERCEL_NODE_BUILDER_ORG_ID }}
+      VERCEL_WITH_REDWOOD_PROJECT_ID: ${{ secrets.VERCEL_WITH_REDWOOD_PROJECT_ID }}
+      VERCEL_WITH_REDWOOD_ORG_ID: ${{ secrets.VERCEL_WITH_REDWOOD_ORG_ID }}
+      VERCEL_WITH_NEXTJS_PROJECT_ID: ${{ secrets.VERCEL_WITH_NEXTJS_PROJECT_ID }}
+      VERCEL_WITH_NEXTJS_ORG_ID: ${{ secrets.VERCEL_WITH_NEXTJS_ORG_ID }}
+      VERCEL_API_PROJECT_ID: ${{ secrets.VERCEL_API_PROJECT_ID }}
+      VERCEL_API_ORG_ID: ${{ secrets.VERCEL_API_ORG_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      NETLIFY_BETA_PG_URL: ${{ secrets.NETLIFY_BETA_PG_URL }}
+      NETLIFY_BUILD_LIFECYCLE_TRIAL: ${{ secrets.NETLIFY_BUILD_LIFECYCLE_TRIAL }}
+      AZURE_FUNCTIONS_LINUX_PG_URL: ${{ secrets.AZURE_FUNCTIONS_LINUX_PG_URL }}
+      AZURE_FUNCTIONS_WINDOWS_PG_URL: ${{ secrets.AZURE_FUNCTIONS_WINDOWS_PG_URL }}
+      AZURE_SP_TENANT: ${{ secrets.AZURE_SP_TENANT }}
+      AZURE_SP_PASSWORD: ${{ secrets.AZURE_SP_PASSWORD }}
+      AZURE_SP_NAME: ${{ secrets.AZURE_SP_NAME }}
+      FIREBASE_FUNCTIONS_PG_URL: ${{ secrets.FIREBASE_FUNCTIONS_PG_URL }}
+      FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      SERVERLESS_LAMBDA_PG_URL: ${{ secrets.SERVERLESS_LAMBDA_PG_URL }}
+
+    steps:
+      - uses: actions/checkout@v2
 
       - name: use node 12
         uses: actions/setup-node@v2
@@ -540,7 +624,7 @@ jobs:
       - name: Install Dependencies
         run: yarn
 
-      - name: test ${{ matrix.platform }} - ${{matrix.engine}}
+      - name: test ${{ matrix.platform }} - napi
         id: run-test
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,6 +128,9 @@ jobs:
         engine: ['napi', 'binary']
         feature: [auto-reconnect, browser-build, studio, napi-preview-feature]
         os: [ubuntu-latest] #, windows-latest, macos-latest]
+        exclude:
+          - engine: napi
+            feature: studio
     runs-on: ${{ matrix.os }}
 
     env:
@@ -564,6 +567,7 @@ jobs:
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:
         - platform: azure-functions-windows
+        - platform: azure-functions-linux
     runs-on: ${{ matrix.os }}
 
     env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -228,7 +228,7 @@ jobs:
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:
         - engine: napi
-          node: 10.16.0
+          node: 10.16.0 # not supported by napi-rs
     runs-on: ${{ matrix.os }}
 
     env:
@@ -566,8 +566,8 @@ jobs:
           - serverless-framework-lambda
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:
-        - platform: azure-functions-windows
-        - platform: azure-functions-linux
+        - platform: azure-functions-windows  # 32 bit Node by default, see https://github.com/prisma/e2e-tests/issues/1748
+        - platform: azure-functions-linux  # Env vars not passed to n-api, see https://github.com/prisma/e2e-tests/issues/1748
     runs-on: ${{ matrix.os }}
 
     env:

--- a/platforms-serverless/serverless-framework-lambda/serverless.yml
+++ b/platforms-serverless/serverless-framework-lambda/serverless.yml
@@ -20,4 +20,6 @@ functions:
 package:
   patterns:
     - '!node_modules/.prisma/client/query-engine-*'
+    - '!node_modules/.prisma/client/libquery_engine_napi-*'
+    - 'node_modules/.prisma/client/libquery_engine_napi-rhel-openssl-1.0.x.so.node'
     - 'node_modules/.prisma/client/query-engine-rhel-openssl-1.0.x'

--- a/platforms-serverless/serverless-framework-lambda/test.ts
+++ b/platforms-serverless/serverless-framework-lambda/test.ts
@@ -9,11 +9,13 @@ async function main() {
   console.log({ data: data.$response.data })
 
   const actual = (data.$response.data as any).Payload
-  const binaryString = `,"files":["index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]`
+  const binaryString = (process.env.PRISMA_FORCE_NAPI = 'true'
+    ? `,"files":["index-browser.js","index.d.ts","index.js","libquery_engine_napi-debian-openssl-1.1.x.so.node","libquery_engine_napi-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
+    : `,"files":["index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]`)
   const expect = `{"version":"${Prisma.prismaVersion.client}","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}${binaryString}}`
 
   if (actual !== expect) {
-    console.log('expected', expect, 'but got', actual)
+    console.log('Expected: \n', expect, '\nBut Got:\n', actual)
     process.exit(1)
   }
 

--- a/platforms-serverless/serverless-framework-lambda/test.ts
+++ b/platforms-serverless/serverless-framework-lambda/test.ts
@@ -9,9 +9,9 @@ async function main() {
   console.log({ data: data.$response.data })
 
   const actual = (data.$response.data as any).Payload
-  const binaryString = (process.env.PRISMA_FORCE_NAPI = 'true'
+  const binaryString = process.env.PRISMA_FORCE_NAPI === 'true'
     ? `,"files":["index-browser.js","index.d.ts","index.js","libquery_engine_napi-debian-openssl-1.1.x.so.node","libquery_engine_napi-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
-    : `,"files":["index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]`)
+    : `,"files":["index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]`
   const expect = `{"version":"${Prisma.prismaVersion.client}","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}${binaryString}}`
 
   if (actual !== expect) {

--- a/platforms-serverless/serverless-framework-lambda/test.ts
+++ b/platforms-serverless/serverless-framework-lambda/test.ts
@@ -10,7 +10,7 @@ async function main() {
 
   const actual = (data.$response.data as any).Payload
   const binaryString = process.env.PRISMA_FORCE_NAPI === 'true'
-    ? `,"files":["index-browser.js","index.d.ts","index.js","libquery_engine_napi-debian-openssl-1.1.x.so.node","libquery_engine_napi-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
+    ? `,"files":["index-browser.js","index.d.ts","index.js","libquery_engine_napi-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
     : `,"files":["index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]`
   const expect = `{"version":"${Prisma.prismaVersion.client}","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}${binaryString}}`
 

--- a/platforms/aws-graviton/run.sh
+++ b/platforms/aws-graviton/run.sh
@@ -4,8 +4,21 @@ set -eu
 
 sh sync-to-remote.sh
 
-ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
-    cd /home/ec2-user/aws-graviton/; 
-    yarn;
-    yarn prisma generate;
-"
+if [ -z ${PRISMA_FORCE_NAPI+x} ]; then
+  echo "N-API:  Disabled"
+  ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
+      cd /home/ec2-user/aws-graviton/;
+      yarn;
+      yarn prisma generate;
+  "
+else
+  echo "N-API: Enabled"
+  ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
+      cd /home/ec2-user/aws-graviton/;
+      export PRISMA_FORCE_NAPI=\"true\";
+      yarn;
+      yarn prisma generate;
+  "
+fi
+
+


### PR DESCRIPTION
- [x]  aws-graviton
- [ ]  ~~azure-functions-linux~~ (still excluded)
- [ ]  ~~studio~~  (still excluded)
- [ ]  ~~azure-functions-windows~~ (still excluded)
- [x]  serverless-framework-lambda
- [ ]  ~~node: 10.16.0~~ (not supported by `napi-rs`)
- [x]  node: 12.2.0

Remaining exclusions moved to this [issue](https://github.com/prisma/e2e-tests/issues/1748)