### PR TITLE
fix(napi): Remove node 10.16.0 exclusion

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -226,9 +226,6 @@ jobs:
           - 15
           - 16
         os: [ubuntu-latest] #, windows-latest, macos-latest]
-        exclude:
-        - engine: napi
-          node: 10.16.0 # not supported by napi-rs
     runs-on: ${{ matrix.os }}
 
     env:


### PR DESCRIPTION
Node 10.16 works fundamentally.

Follow up issue: https://github.com/prisma/e2e-tests/issues/1750