### PR TITLE
fix(netlify-ci): Use path.dirname(require.resolve('.prisma/client')) instead of hardcoded path to get `files`

### DIFF
--- a/platforms-serverless/netlify-ci/functions/index.js
+++ b/platforms-serverless/netlify-ci/functions/index.js
@@ -42,8 +42,9 @@ exports.handler = async function (event, context, callback) {
  
   // list all files in node_modules/.prisma/client
   const fs = require('fs')
-  const files = fs.readdirSync(process.env.LAMBDA_TASK_ROOT + "/src/node_modules/.prisma/client")
-
+  const path = require('path')
+  const files = fs.readdirSync(path.dirname(require.resolve('.prisma/client')))
+  
   return {
     statusCode: 200,
     body: JSON.stringify({


### PR DESCRIPTION
This fixes the failing netlify-ci tests by resolving the path instead of using a hardcoded one (which Netlify seems to have changed recently...)