### PR TITLE
fix(aws-graviton): Make tests more resilient by using individual folder per run

### DIFF
--- a/platforms/aws-graviton/finally.sh
+++ b/platforms/aws-graviton/finally.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+ssh -tt -i ./server-key.pem ec2-user@54.72.209.131 "rm -rf /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID"
+

--- a/platforms/aws-graviton/run.sh
+++ b/platforms/aws-graviton/run.sh
@@ -1,23 +1,25 @@
 #!/bin/sh
 
-set -eu
+set -eux
 
 sh sync-to-remote.sh
 
 if [ -z ${PRISMA_FORCE_NAPI+x} ]; then
-  echo "N-API:  Disabled"
+  echo "N-API: Disabled"
   ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
-      cd /home/ec2-user/aws-graviton/;
+      cd /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID;
       yarn;
       yarn prisma generate;
+      yarn prisma -v;
   "
 else
   echo "N-API: Enabled"
   ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
-      cd /home/ec2-user/aws-graviton/;
+      cd /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID;
       export PRISMA_FORCE_NAPI=\"true\";
       yarn;
       yarn prisma generate;
+      yarn prisma -v;
   "
 fi
 

--- a/platforms/aws-graviton/sync-to-remote.sh
+++ b/platforms/aws-graviton/sync-to-remote.sh
@@ -1,14 +1,16 @@
 #!/bin/sh
 
-set -eu
+set -eux
 
 echo "Sync: Syncing code to EC2"
 
 echo "Sync: Removing local node_modules"
 rm -rf ./code/node_modules
 
-echo "Sync: Removing existing code"
-ssh -tt -i ./server-key.pem ec2-user@54.72.209.131 'rm -rf /home/ec2-user/aws-graviton'
+echo "Sync: Create remote folder"
+ssh -tt -i ./server-key.pem ec2-user@54.72.209.131 "mkdir -p /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID"
 
-echo "Sync: Copying new code"
-scp -i ./server-key.pem -rp ./code ec2-user@54.72.209.131:/home/ec2-user/aws-graviton/
+echo "Sync: Copy code to unique folder"
+scp -i ./server-key.pem -rp ./code/* ec2-user@54.72.209.131:/home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID/
+
+echo "sync-to-remote done"

--- a/platforms/aws-graviton/test.sh
+++ b/platforms/aws-graviton/test.sh
@@ -3,6 +3,6 @@
 set -eu
 
 ssh -i ./server-key.pem ec2-user@54.72.209.131 -tt "
-    cd /home/ec2-user/aws-graviton/; 
+    cd /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID; 
     yarn test;
 "


### PR DESCRIPTION
Right now all aws-graviton tests work in the same folder on the same server - overwriting each others data when they run at the same time. This is of course a good way to get failing tests for no reason.

This PR makes them use their own subfolder each instead.