### PR TITLE
chore: remove prisma from root `node_modules`

### DIFF
--- a/core-features/client-install-on-generate/run.sh
+++ b/core-features/client-install-on-generate/run.sh
@@ -5,4 +5,4 @@ set -eux
 yarn install
 yarn remove @prisma/client
 
-yarn prisma generate
+env DEBUG="prisma:generator" yarn prisma generate

--- a/core-features/client-install-on-generate/run.sh
+++ b/core-features/client-install-on-generate/run.sh
@@ -5,4 +5,4 @@ set -eux
 yarn install
 yarn remove @prisma/client
 
-env DEBUG="prisma:generator" yarn prisma generate
+yarn prisma generate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@prisma/client": "2.26.0-dev.19",
     "arg": "5.0.0",
     "fetch-retry": "4.1.1",
     "glob": "7.1.7",
@@ -9,7 +8,6 @@
   },
   "devDependencies": {
     "@types/node": "14.14.30",
-    "prisma": "2.26.0-dev.19",
     "ts-node": "9.1.1",
     "typescript": "4.2.4"
   },


### PR DESCRIPTION
Fixes https://prisma-company.slack.com/archives/D01SYV72V9T/p1624383670000100

If we delete the `@prisma/client` in our test then it fetches the one at the root. However, that is not needed. The dependency was added to the root `package.json` on `prisma generate` when not found.