### PR TITLE
fix(check update): ignore redwood "api" package.json file

### DIFF
--- a/.github/scripts/check-for-update.sh
+++ b/.github/scripts/check-for-update.sh
@@ -46,8 +46,8 @@ git fetch github "$branch"
 git reset --hard "github/$branch"
 git checkout "github/$branch"
 
-# prepare script: read package.json but ignore workspace package.json files, redwood "web" package.json file
-pkg="var pkg=require('./package.json'); if (pkg.workspaces || pkg.name == '.prisma/client' || pkg.name == 'web') { process.exit(0); }"
+# prepare script: read package.json but ignore workspace package.json files, redwood "web" and "api" package.json file
+pkg="var pkg=require('./package.json'); if (pkg.workspaces || pkg.name == '.prisma/client' || pkg.name == 'web' || pkg.name == 'api') { process.exit(0); }"
 
 # since GH actions are limited to 5 minute cron jobs, just run this continuously for 5 minutes
 minutes=5   # cron job runs each x minutes


### PR DESCRIPTION
e2e check-update job in GitHub Actions started to fail yesterday around noon for
check-for-integration-update
and more important for release today, the check-for-dev-update
 running ./platforms-serverless/vercel-with-redwood/web/package.json with ……. error An unexpected error occurred: "expected workspace package to exist for \"@babel/core\"".
Full logs for yesterday run
https://github.com/prisma/e2e-tests/runs/3160768251?check_suite_focus=true#step:4:3342
And most recent run logs
https://github.com/prisma/e2e-tests/runs/3169150594?check_suite_focus=true#step:4:3408