### PR TITLE
fix(serverless-framework-lambda): Make retries work by overwriting credentials config

### DIFF
--- a/platforms-serverless/serverless-framework-lambda/prepare.sh
+++ b/platforms-serverless/serverless-framework-lambda/prepare.sh
@@ -9,4 +9,4 @@ x="$AWS_SECRET_ACCESS_KEY"
 x="$AWS_ROLE"
 
 yarn install
-yarn serverless config credentials --provider aws --key "$AWS_ACCESS_KEY_ID" --secret "$AWS_SECRET_ACCESS_KEY"
+yarn serverless config credentials --provider aws --key "$AWS_ACCESS_KEY_ID" --secret "$AWS_SECRET_ACCESS_KEY" --overwrite


### PR DESCRIPTION
Avoids:

```
$ /home/runner/work/e2e-tests/e2e-tests/platforms-serverless/serverless-framework-lambda/node_modules/.bin/serverless config credentials --provider aws --key *** --secret ***
Serverless: Setting up AWS...
 
 Serverless Error ----------------------------------------
 
  Profile "default" is already configured in ~/.aws/credentials. Use the overwrite flag ("-o" or "--overwrite") to force the update.
```