### PR TITLE
chore: vercel-with-redwood tests timeout 5 to 10s

### DIFF
--- a/platforms-serverless/vercel-with-redwood/index.test.js
+++ b/platforms-serverless/vercel-with-redwood/index.test.js
@@ -18,7 +18,7 @@ test('should test prisma version', async () => {
   `
   const data = await request(endpoint, query)
   expect(data.prismaVersion).toEqual(pjson.dependencies['@prisma/client'])
-})
+}, 10000)
 
 test('should query graphql users', async () => {
   const query = gql`
@@ -32,7 +32,7 @@ test('should query graphql users', async () => {
   `
   const data = await request(endpoint, query)
   expect(data).toMatchSnapshot()
-})
+}, 10000)
 
 test('should test .prisma/client files', async () => {
   const query = gql`


### PR DESCRIPTION
Happened during 3.6.0 release with https://github.com/prisma/e2e-tests/actions/runs/1521572907
```
FAIL ./index.test.js (15.124 s)
  ✕ should test prisma version (5002 ms)
  ✓ should query graphql users (4660 ms)
  ✓ should test .prisma/client files (2971 ms)

  ● should test prisma version

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."
```