### PR TITLE
fix(engines/engine-types): engineType should be a string

### DIFF
--- a/engines/engine-types/utils.ts
+++ b/engines/engine-types/utils.ts
@@ -33,7 +33,7 @@ datasource db {
     ? `previewFeatures = ${options.previewFeatures.map((p) => `["${p}"]`)}`
     : ''
   const clientEngineType = options?.engineType
-    ? `engineType = ${options.engineType}`
+    ? `engineType = "${options.engineType}"`
     : ''
   const binaryTargetsStr = options?.binaryTargets
     ? `binaryTargets = ${options.binaryTargets.map((p) => `["${p}"]`)}`


### PR DESCRIPTION
`engines (engine-types, *)`

started to fail with https://github.com/prisma/e2e-tests/runs/4699774043?check_suite_focus=true#step:6:369
```
Error: Get config: Schema Parsing P1012

error: Expected a String value, but received literal value `binary`.
  -->  schema.prisma:9
   | 
 8 |   
 9 |   engineType = binary
   | 
```

Should be because of this new change https://github.com/prisma/prisma-engines/pull/2549
That only allows the value to be a string.

Somehow this was valid before
```
  engineType = binary
```
now only this is valid
```
  engineType = "binary"
```