### PR TITLE
test(workers): add console.debug

### DIFF
--- a/workers/cloudflare-workers/index.test.ts
+++ b/workers/cloudflare-workers/index.test.ts
@@ -7,7 +7,11 @@ describe('use data proxy', () => {
     jest.setTimeout(30000)
 
     const cloudflareWorkersDeploymentUrl = process.env.DEPLOYMENT_URL!
-    const response = await fetch(cloudflareWorkersDeploymentUrl )
+    console.debug(cloudflareWorkersDeploymentUrl)
+    
+    const response = await fetch(cloudflareWorkersDeploymentUrl)
+    console.debug(await response.text())
+    
     const jsonData = await response.json()
 
     expect(jsonData).toMatchInlineSnapshot(`

--- a/workers/cloudflare-workers/index.test.ts
+++ b/workers/cloudflare-workers/index.test.ts
@@ -10,10 +10,11 @@ describe('use data proxy', () => {
     console.debug(cloudflareWorkersDeploymentUrl)
     
     const response = await fetch(cloudflareWorkersDeploymentUrl)
-    console.debug(await response.text())
     
-    const jsonData = await response.json()
-
+    const bodyAsText = await response.text()
+    console.debug(bodyAsText)
+    
+    const jsonData = JSON.parse(bodyAsText)
     expect(jsonData).toMatchInlineSnapshot(`
 Object {
   "data": Array [

--- a/workers/vercel-edge-functions/index.test.ts
+++ b/workers/vercel-edge-functions/index.test.ts
@@ -7,9 +7,12 @@ describe('use data proxy', () => {
     jest.setTimeout(30000)
 
     const vercelEdgeFunctionsDeployment = process.env.DEPLOYMENT_URL!
+    console.debug(vercelEdgeFunctionsDeployment)
+    
     const response = await fetch(vercelEdgeFunctionsDeployment)
+    console.debug(await response.text())
+    
     const jsonData = await response.json()
-
     expect(jsonData).toMatchInlineSnapshot(`
 Object {
   "data": Array [

--- a/workers/vercel-edge-functions/index.test.ts
+++ b/workers/vercel-edge-functions/index.test.ts
@@ -10,9 +10,11 @@ describe('use data proxy', () => {
     console.debug(vercelEdgeFunctionsDeployment)
     
     const response = await fetch(vercelEdgeFunctionsDeployment)
-    console.debug(await response.text())
+
+    const bodyAsText = await response.text()
+    console.debug(bodyAsText)
     
-    const jsonData = await response.json()
+    const jsonData = JSON.parse(bodyAsText)
     expect(jsonData).toMatchInlineSnapshot(`
 Object {
   "data": Array [


### PR DESCRIPTION
Useful to easily debug the following 
https://github.com/prisma/e2e-tests/runs/4743505459?check_suite_focus=true#step:6:582
```
 vercel-edge-functions-le869lpnx-prisma.vercel.app
yarn run v1.22.17
warning ../../package.json: No license field
$ jest
FAIL ./index.test.ts
  use data proxy
    ✕ fetch response (698 ms)

  ● use data proxy › fetch response

    FetchError: invalid json response body at vercel-edge-functions-le869lpnx-prisma.vercel.app reason: Unexpected token A in JSON at position 0

      at node_modules/node-fetch/lib/index.js:273:32
```