### PR TITLE
chore: Revert "fix(deps): update dependency @slack/webhook to v6"

### DIFF
--- a/.github/slack/package.json
+++ b/.github/slack/package.json
@@ -6,6 +6,6 @@
   ],
   "description": "",
   "dependencies": {
-    "@slack/webhook": "6.0.0"
+    "@slack/webhook": "5.0.4"
   }
 }

--- a/.github/slack/yarn.lock
+++ b/.github/slack/yarn.lock
@@ -7,19 +7,19 @@
   resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.4.0.tgz#24e0f0cd5b3c4578a7e023aba97969d89c667562"
   integrity sha512-G5u2gCl7oci0k4E9KIX33nmA4YPp1pXYwS/It7ct9dOglCcj63Ee5GRCgtplzOBS+2++DMdp6l3ZCq+VeAMrfw==
 
-"@slack/webhook@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@slack/webhook/-/webhook-6.0.0.tgz#844593c1e864a966e549f60bb640586628f3c1c4"
-  integrity sha512-2fohfhLI9lkAmOSWt1R457JBsB3iFNqahu4GqdFZRtcp/bT+xeG/kPn/hQa78JS74poRjWTt5G/qJjNaWMGOEQ==
+"@slack/webhook@5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@slack/webhook/-/webhook-5.0.4.tgz#5d3e947387c1d0ccb176a153cec68c594edb7060"
+  integrity sha512-IC1dpVSc2F/pmwCxOb0QzH2xnGKmyT7MofPGhNkeaoiMrLMU+Oc7xV/AxGnz40mURtCtaDchZSM3tDo9c9x6BA==
   dependencies:
     "@slack/types" "^1.2.1"
-    "@types/node" ">=12.0.0"
+    "@types/node" ">=8.9.0"
     axios "^0.21.1"
 
-"@types/node@>=12.0.0":
-  version "17.0.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.8.tgz#50d680c8a8a78fe30abe6906453b21ad8ab0ad7b"
-  integrity sha512-YofkM6fGv4gDJq78g4j0mMuGMkZVxZDgtU0JRdx6FgiJDG+0fY0GKVolOV8WqVmEhLCXkQRjwDdKyPxJp/uucg==
+"@types/node@>=8.9.0":
+  version "13.7.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
+  integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
 
 axios@^0.21.1:
   version "0.21.1"


### PR DESCRIPTION
Reverts prisma/e2e-tests#2282

https://github.com/prisma/e2e-tests/pull/2282#issuecomment-1011070043