### PR TITLE
test: temporary disable serverless framework test

### DIFF
--- a/.github/scripts/check-folders.js
+++ b/.github/scripts/check-folders.js
@@ -13,6 +13,7 @@ async function main() {
     .filter((file) => {
       const ignoreFiles = [
         'package.json', // package.json at root
+        'platforms-serverless/serverless-framework-lambda', // Temporary disabled
         'platforms-serverless/vercel-with-redwood/api', // Redwood uses workspaces but is included
         'platforms-serverless/vercel-with-redwood/web', // Redwood uses workspaces but is included
         'platforms-serverless/firebase-functions/functions', // Firebase root doesn't have package.json but is included

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -693,7 +693,7 @@ jobs:
           - firebase-functions
           - azure-functions-linux
           - azure-functions-windows
-          - serverless-framework-lambda
+          # - serverless-framework-lambda Temporary disable
         clientEngine: ['library', 'binary']
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:


### PR DESCRIPTION
It will make Renovate automerge work again

I will create the revert PR right away with Slack reminder after we merge this so we don't forget to reactivate once Dom unblocks the AWS policy
