### PR TITLE
ci: fix detect jobs with Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": ["config:base"],
   "reviewers": ["@Jolg42", "@millsp"],
   "automerge": true,
-  "automergeType": "branch",
   "major": {
     "automerge": false
   },
@@ -27,10 +26,7 @@
       "groupName": "Webpack 4 - Cloudflare Workers"
     },
     {
-      "matchPaths": [
-        "libraries/type-graphql/**",
-        "community-generators/typegraphql-prisma/**"
-      ],
+      "matchPaths": ["libraries/type-graphql/**", "community-generators/typegraphql-prisma/**"],
       "matchPackageNames": ["graphql"],
       "allowedVersions": "<16",
       "groupName": "GraphQL 15 - TypeGraphQL"


### PR DESCRIPTION
Previous PRs
https://github.com/prisma/e2e-tests/pull/2302
https://github.com/prisma/e2e-tests/pull/2300
First PR at https://github.com/prisma/e2e-tests/pull/2286

Disabling the branch before PR behavior is the only easy solution I see at the moment to make the setup work instantly
https://docs.renovatebot.com/noise-reduction/#branch-automerging