### PR TITLE
chore: revert "test: temporary disable serverless framework test"

### DIFF
--- a/.github/scripts/check-folders.js
+++ b/.github/scripts/check-folders.js
@@ -13,7 +13,6 @@ async function main() {
     .filter((file) => {
       const ignoreFiles = [
         'package.json', // package.json at root
-        'platforms-serverless/serverless-framework-lambda', // Temporary disabled
         'platforms-serverless/vercel-with-redwood/api', // Redwood uses workspaces but is included
         'platforms-serverless/vercel-with-redwood/web', // Redwood uses workspaces but is included
         'platforms-serverless/firebase-functions/functions', // Firebase root doesn't have package.json but is included

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -709,7 +709,7 @@ jobs:
           - firebase-functions
           - azure-functions-linux
           - azure-functions-windows
-          # - serverless-framework-lambda Temporary disable
+          - serverless-framework-lambda
         clientEngine: ['library', 'binary']
         os: [ubuntu-latest] #, windows-latest, macos-latest]
         exclude:

--- a/platforms-serverless/serverless-framework-lambda/run.sh
+++ b/platforms-serverless/serverless-framework-lambda/run.sh
@@ -8,6 +8,8 @@ yarn prisma generate
 
 yarn tsc
 
-# Trying this for debugging and should be removed after
+# Turn serverless CLI logs to verbose
+# Useful for debugging aws permissions errors (and probably more)
 export SLS_DEBUG=*
+
 yarn serverless deploy --region "$AWS_DEFAULT_REGION"

--- a/platforms-serverless/serverless-framework-lambda/run.sh
+++ b/platforms-serverless/serverless-framework-lambda/run.sh
@@ -8,4 +8,6 @@ yarn prisma generate
 
 yarn tsc
 
+# Trying this for debugging and should be removed after
+export SLS_DEBUG=*
 yarn serverless deploy --region "$AWS_DEFAULT_REGION"


### PR DESCRIPTION
Reverts prisma/e2e-tests#2298

To merge when the AWS credentials are working again