### PR TITLE
ci: remove unused gh config for renovate

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,8 +15,6 @@ on:
       - patch-dev
       - latest
       - integration
-      # Push events to branches matching refs/heads/renovate/...
-      - 'renovate/**'
   pull_request:
     paths-ignore:
       - '*.md'


### PR DESCRIPTION
Since we removed "automergeType": "branch" from renovate config in https://github.com/prisma/e2e-tests/commit/7603c6593bdcd062a215d66e4d516229606e2c7a#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57

This special config is not needed and actually creates double runs for renovate branches see first and last of screenshot for example 
<img width="892" alt="Screen Shot 2022-01-19 at 12 09 13" src="https://user-images.githubusercontent.com/1328733/150118634-cb6db806-ca0f-48d7-86f3-071bd410e580.png">
