### PR TITLE
fix(databases/mongodb-digitalocean): Remove `library` exclusion

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -956,10 +956,6 @@ jobs:
           - cockroach-cloud
         clientEngine: ['library', 'binary']
         os: [ubuntu-latest] #, windows-latest, macos-latest]
-        exclude:
-          # excludes mongodb-digitalocean for library engine (to be added again later)
-          - database: 'mongodb-digitalocean'
-            clientEngine: 'library'
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Should now work after https://github.com/prisma/prisma-engines/pull/2760 has been merged.