### PR TITLE
chore: rename from e2e-tests to ecosystem-tests

### DIFF
--- a/.github/scripts/check-folders.js
+++ b/.github/scripts/check-folders.js
@@ -87,7 +87,7 @@ async function main() {
     process.exit(0)
   } else {
     console.log(
-      'There are some folders in e2e-tests that are not used in test.yaml or optional-test.yaml workflows',
+      'There are some folders in ecosystem-tests that are not used in test.yaml or optional-test.yaml workflows',
     )
     console.log(remainingFolders)
     process.exit(1)

--- a/.github/scripts/slack-workflow-status.sh
+++ b/.github/scripts/slack-workflow-status.sh
@@ -14,7 +14,7 @@ sha="$(git rev-parse HEAD)"
 short_sha="$(echo "$sha" | cut -c -7)"
 message="$(git log -1 --pretty=%B | head -n 1)"
 
-commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
-workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$message>"
+commit_link="\`<https://github.com/prisma/ecosystem-tests/commit/$sha|$branch@$short_sha>\`"
+workflow_link="<https://github.com/prisma/ecosystem-tests/actions/runs/$GITHUB_RUN_ID|$message>"
 
 node .github/slack/notify.js "prisma@$version: $emoji $workflow_link (via $commit_link)"

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -128,8 +128,8 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/integra
   branch="${GITHUB_REF##*/}"
   sha="$(git rev-parse HEAD | cut -c -7)"
   short_sha="$(echo "$sha" | cut -c -7)"
-  commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
-  workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
+  commit_link="\`<https://github.com/prisma/ecosystem-tests/commit/$sha|$branch@$short_sha>\`"
+  workflow_link="<https://github.com/prisma/ecosystem-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
 
   export webhook="$SLACK_WEBHOOK_URL"
   version="$(cat .github/prisma-version.txt)"

--- a/.github/slack/notify-failure.sh
+++ b/.github/slack/notify-failure.sh
@@ -14,8 +14,8 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/integra
   branch="${GITHUB_REF##*/}"
   sha="$(git rev-parse HEAD | cut -c -7)"
   short_sha="$(echo "$sha" | cut -c -7)"
-  commit_link="\`<https://github.com/prisma/e2e-tests/commit/$sha|$branch@$short_sha>\`"
-  workflow_link="<https://github.com/prisma/e2e-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
+  commit_link="\`<https://github.com/prisma/ecosystem-tests/commit/$sha|$branch@$short_sha>\`"
+  workflow_link="<https://github.com/prisma/ecosystem-tests/actions/runs/$GITHUB_RUN_ID|$project $matrix>"
 
   export webhook="$SLACK_WEBHOOK_URL"
   version="$(cat .github/prisma-version.txt)"

--- a/.github/workflows/check-for-update.yaml
+++ b/.github/workflows/check-for-update.yaml
@@ -9,7 +9,7 @@ on:
 concurrency: check-for-update
 
 env:
-  PRISMA_TELEMETRY_INFORMATION: 'e2e-tests check-for-update.yaml'
+  PRISMA_TELEMETRY_INFORMATION: 'ecosystem-tests check-for-update.yaml'
 
 jobs:
   check-for-latest-update:

--- a/.github/workflows/detect-jobs-to-run.js
+++ b/.github/workflows/detect-jobs-to-run.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // @ts-check
 
-// This was originally done in prisma/prisma repository and adapted to e2e
+// This was originally done in prisma/prisma repository and adapted to ecosystem
 // https://github.com/prisma/prisma/blob/main/.github/workflows/detect-jobs-to-run.js
 
 const yaml = require('yaml')

--- a/.github/workflows/optional-test.yaml
+++ b/.github/workflows/optional-test.yaml
@@ -7,7 +7,7 @@ on:
       - 'renovate.json'
 
 env:
-  PRISMA_TELEMETRY_INFORMATION: 'e2e-tests optional-test.yaml'
+  PRISMA_TELEMETRY_INFORMATION: 'ecosystem-tests optional-test.yaml'
   SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_OPTIONAL_WORKFLOWS }}
   CI: 1
   # TODO: Consolidate these env vars. They shouldn't be required for slack notification

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ on:
       - 'renovate.json'
 
 env:
-  PRISMA_TELEMETRY_INFORMATION: 'e2e-tests test.yaml'
+  PRISMA_TELEMETRY_INFORMATION: 'ecosystem-tests test.yaml'
   CI: 1
   SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_WORKFLOWS }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/upgrade-branch-to-version.yaml
+++ b/.github/workflows/upgrade-branch-to-version.yaml
@@ -13,7 +13,7 @@ on:
         required: true
 
 env:
-  PRISMA_TELEMETRY_INFORMATION: 'e2e-tests upgrade-branch-to-version.yaml'
+  PRISMA_TELEMETRY_INFORMATION: 'ecosystem-tests upgrade-branch-to-version.yaml'
 
 jobs:
   upgrade-branch-to-version:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Renovate is enabled for this repository for all dependencies except `prisma` and
 
 #### Prisma
 
-When there is a new version, [Prismo](https://github.com/prisma-bot) works tirelessly to commit and push a bump commit, triggering the ecosystem tests. This is implemented in `.github/workflows/check-for-update.yaml` using a GitHub Action cron job. Since the cron job is limited to run each 5 minutes, we just run each cron job for exactly 5 minutes and check for updates each 10 seconds in each run. This check only runs in the default branch `dev`.
+When there is a new version, [Prismo](https://github.com/prisma-bot) works tirelessly to commit and push a bump commit, triggering the tests. This is implemented in `.github/workflows/check-for-update.yaml` using a GitHub Action cron job. Since the cron job is limited to run each 5 minutes, we just run each cron job for exactly 5 minutes and check for updates each 10 seconds in each run. This check only runs in the default branch `dev`.
 
 ### Branches and npm channels
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can check out the latest test runs by checking the ["test" workflow results]
 
 ### Projects and Tests
 
-The ecosystem tests are defined in `.github/workflows/test.yaml` and `.github/workflows/optional-test.yaml`, and the test projects live in folder of form `foo/bar` in this repository. Each `foo` has one or multiple jobs in the GitHub Actions Workflows, and the `bar`s are part of the matrix per job.
+The tests are defined in `.github/workflows/test.yaml` and `.github/workflows/optional-test.yaml`, and the test projects live in folder of form `foo/bar` in this repository. Each `foo` has one or multiple jobs in the GitHub Actions Workflows, and the `bar`s are part of the matrix per job.
 
 All of the jobs run `.github/scripts/test-project.sh`, which then executes the test project.
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# Prisma e2e Tests
+# Prisma Ecosystem Tests
 
 This repository continuously tests Prisma Client on and with various operating systems, databases, frameworks, platforms and other setups.
 
 | CI Status                                                                                                                                                                                      | Branch        |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
-| [![test dev](https://github.com/prisma/e2e-tests/workflows/test/badge.svg?branch=dev)](https://github.com/prisma/e2e-tests/actions?query=workflow%3Atest+branch%3Adev) | `dev` |
-| [![test latest](https://github.com/prisma/e2e-tests/workflows/test/badge.svg?branch=latest)](https://github.com/prisma/e2e-tests/actions?query=workflow%3Atest+branch%3Alatest)                | `latest`      |
-| [![test patch-dev](https://github.com/prisma/e2e-tests/workflows/test/badge.svg?branch=patch-dev)](https://github.com/prisma/e2e-tests/actions?query=workflow%3Atest+branch%3Apatch-dev)       | `patch-dev`   |
-| [![test integration](https://github.com/prisma/e2e-tests/workflows/test/badge.svg?branch=integration)](https://github.com/prisma/e2e-tests/actions?query=workflow%3Atest+branch%3Aintegration) | `integration` |
-| [![check-for-update](https://github.com/prisma/e2e-tests/workflows/check-for-update/badge.svg)](https://github.com/prisma/e2e-tests/actions?query=workflow%3Acheck-for-update)                 | -             |
+| [![test dev](https://github.com/prisma/ecosystem-tests/workflows/test/badge.svg?branch=dev)](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3Adev) | `dev` |
+| [![test latest](https://github.com/prisma/ecosystem-tests/workflows/test/badge.svg?branch=latest)](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3Alatest)                | `latest`      |
+| [![test patch-dev](https://github.com/prisma/ecosystem-tests/workflows/test/badge.svg?branch=patch-dev)](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3Apatch-dev)       | `patch-dev`   |
+| [![test integration](https://github.com/prisma/ecosystem-tests/workflows/test/badge.svg?branch=integration)](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest+branch%3Aintegration) | `integration` |
+| [![check-for-update](https://github.com/prisma/ecosystem-tests/workflows/check-for-update/badge.svg)](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Acheck-for-update)                 | -             |
 
 
-You can check out the latest test runs by checking the ["test" workflow results](https://github.com/prisma/e2e-tests/actions?query=workflow%3Atest).
+You can check out the latest test runs by checking the ["test" workflow results](https://github.com/prisma/ecosystem-tests/actions?query=workflow%3Atest).
 
 ## How it works
 
 ### Projects and Tests
 
-The e2e tests are defined in `.github/workflows/test.yaml` and `.github/workflows/optional-test.yaml`, and the test projects live in folder of form `foo/bar` in this repository. Each `foo` has one or multiple jobs in the GitHub Actions Workflows, and the `bar`s are part of the matrix per job.
+The ecosystem tests are defined in `.github/workflows/test.yaml` and `.github/workflows/optional-test.yaml`, and the test projects live in folder of form `foo/bar` in this repository. Each `foo` has one or multiple jobs in the GitHub Actions Workflows, and the `bar`s are part of the matrix per job.
 
 All of the jobs run `.github/scripts/test-project.sh`, which then executes the test project.
 
@@ -47,7 +47,7 @@ Renovate is enabled for this repository for all dependencies except `prisma` and
 
 #### Prisma
 
-When there is a new version, [Prismo](https://github.com/prisma-bot) works tirelessly to commit and push a bump commit, triggering the e2e tests. This is implemented in `.github/workflows/check-for-update.yaml` using a GitHub Action cron job. Since the cron job is limited to run each 5 minutes, we just run each cron job for exactly 5 minutes and check for updates each 10 seconds in each run. This check only runs in the default branch `dev`.
+When there is a new version, [Prismo](https://github.com/prisma-bot) works tirelessly to commit and push a bump commit, triggering the ecosystem tests. This is implemented in `.github/workflows/check-for-update.yaml` using a GitHub Action cron job. Since the cron job is limited to run each 5 minutes, we just run each cron job for exactly 5 minutes and check for updates each 10 seconds in each run. This check only runs in the default branch `dev`.
 
 ### Branches and npm channels
 

--- a/databases/digitalocean-pgbouncer/README.md
+++ b/databases/digitalocean-pgbouncer/README.md
@@ -2,7 +2,7 @@
 
 Tests PgBouncer on DigitalOcean, connection string has `pgbouncer=true` query param added.
 
-We have two test case, one that doesn't use the `pgbouncer=true` query param and fails and another which uses the `pgbouncer=true` query param and succeeds. (TODO This is not true at the moment, the tests pass even without the `pgbouncer=true` flag, this is unexpected and being tracked here https://github.com/prisma/e2e-tests/issues/378)
+We have two test case, one that doesn't use the `pgbouncer=true` query param and fails and another which uses the `pgbouncer=true` query param and succeeds. (TODO This is not true at the moment, the tests pass even without the `pgbouncer=true` flag, this is unexpected and being tracked here https://github.com/prisma/ecosystem-tests/issues/378)
 
 ## How to run this locally
 

--- a/databases/heroku-pgbouncer-buildpack/README.md
+++ b/databases/heroku-pgbouncer-buildpack/README.md
@@ -1,6 +1,6 @@
 # Heroku PgBouncer Buildpack
 
-[Heroku buildpack: pgbouncer](https://github.com/heroku/heroku-buildpack-pgbouncer) allows one to run pgbouncer in a dyno alongside application code. This is different from PgBouncer hosted as a separate infrastructure components (that test is covered in [databases/heroku-pgbouncer](https://github.com/prisma/e2e-tests/tree/dev/databases/heroku-pgbouncer))
+[Heroku buildpack: pgbouncer](https://github.com/heroku/heroku-buildpack-pgbouncer) allows one to run pgbouncer in a dyno alongside application code. This is different from PgBouncer hosted as a separate infrastructure components (that test is covered in [databases/heroku-pgbouncer](https://github.com/prisma/ecosystem-tests/tree/dev/databases/heroku-pgbouncer))
 
 ## How to run this locally
 

--- a/databases/heroku-pgbouncer-buildpack/run.sh
+++ b/databases/heroku-pgbouncer-buildpack/run.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases heroku-pgbouncer-buildpack build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests databases heroku-pgbouncer-buildpack build'
 yarn install
 yarn prisma generate
 

--- a/databases/heroku-pgbouncer/run.sh
+++ b/databases/heroku-pgbouncer/run.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases heroku-pgbouncer build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests databases heroku-pgbouncer build'
 yarn install
 yarn prisma generate

--- a/databases/planetscale/run.sh
+++ b/databases/planetscale/run.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases planetscale run.sh'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests databases planetscale run.sh'
 yarn install
 yarn prisma generate

--- a/databases/supabase-pool/run.sh
+++ b/databases/supabase-pool/run.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests databases supabase-pool build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests databases supabase-pool build'
 yarn install
 yarn prisma generate

--- a/dataproxy/cloudflare-workers/prepare.sh
+++ b/dataproxy/cloudflare-workers/prepare.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests dataproxy cloudflare-workers build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests dataproxy cloudflare-workers build'
 
 source ../../utils/crypto/setEnv.sh CF_ACCOUNT_ID CF_API_TOKEN CF_DATA_PROXY_URL
 
 # we add the data proxy URL into the configuration file directly
-cp -fr wrangler.base.toml wrangler.toml # needed for e2e retries
+cp -fr wrangler.base.toml wrangler.toml # needed for retries
 echo "CF_DATA_PROXY_URL=\"$CF_DATA_PROXY_URL\"" >> wrangler.toml
 
 # we tell prisma to generate with the dataproxy runtime enabled

--- a/dataproxy/nodejs/prepare.sh
+++ b/dataproxy/nodejs/prepare.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests dataproxy nodejs build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests dataproxy nodejs build'
 
 source ../../utils/crypto/setEnv.sh NODEJS_DATA_PROXY_URL
 

--- a/dataproxy/vercel-edge-functions/prepare.sh
+++ b/dataproxy/vercel-edge-functions/prepare.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests dataproxy vercel-edge-functions build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests dataproxy vercel-edge-functions build'
 
 source ../../utils/crypto/setEnv.sh VERCEL_DATA_PROXY_URL VERCEL_EDGE_FUNCTIONS_PROJECT_ID
 

--- a/platforms-serverless/firebase-functions/functions/package.json
+++ b/platforms-serverless/firebase-functions/functions/package.json
@@ -8,7 +8,7 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "postinstall": "CI=1 && PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms/firebase-functions postinstall' && yarn prisma generate"
+    "postinstall": "CI=1 && PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms/firebase-functions postinstall' && yarn prisma generate"
   },
   "dependencies": {
     "@prisma/client": "3.12.0-dev.17",

--- a/platforms-serverless/gcp-functions/package.json
+++ b/platforms-serverless/gcp-functions/package.json
@@ -2,7 +2,7 @@
   "name": "script",
   "license": "MIT",
   "scripts": {
-    "postinstall": "CI=1 && PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms/gcp-functions postinstall' && yarn prisma generate"
+    "postinstall": "CI=1 && PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms/gcp-functions postinstall' && yarn prisma generate"
   },
   "devDependencies": {
     "prisma": "3.12.0-dev.17",

--- a/platforms-serverless/gcp-functions/run.sh
+++ b/platforms-serverless/gcp-functions/run.sh
@@ -24,4 +24,4 @@ yarn tsc
 func="e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$func" > func-tmp.txt
 
-gcloud functions deploy "$func" --runtime nodejs12 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms azure functions linux gcp functions env'
+gcloud functions deploy "$func" --runtime nodejs12 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms azure functions linux gcp functions env'

--- a/platforms-serverless/lambda/README.md
+++ b/platforms-serverless/lambda/README.md
@@ -23,7 +23,7 @@ The AWS v1 CLI is already pre-installed in GitHub Actions.
 - `AWS_SECRET_ACCESS_KEY`: The AWS secret.
 - `AWS_ACCESS_KEY_ID`: The AWS access key id.
 
-Check 1Password for the values for our e2e account.
+Check 1Password for the values for our ecosystem-tests account.
 
 ### Prepare
 

--- a/platforms-serverless/netlify-ci/package.json
+++ b/platforms-serverless/netlify-ci/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "dev": "npx netlify dev",
-    "build": "PRISMA_TELEMETRY_INFORMATION='e2e-tests platform netlify-ci build' && yarn prisma generate"
+    "build": "PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platform netlify-ci build' && yarn prisma generate"
   },
   "dependencies": {
     "@prisma/client": "3.12.0-dev.17"

--- a/platforms-serverless/netlify-cli/run.sh
+++ b/platforms-serverless/netlify-cli/run.sh
@@ -5,7 +5,7 @@ set -eux
 yarn install
 yarn prisma generate
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms netlify-cli build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms netlify-cli build'
 
 
 # create empty `functions-build` folder

--- a/platforms-serverless/serverless-framework-lambda/README.md
+++ b/platforms-serverless/serverless-framework-lambda/README.md
@@ -11,4 +11,4 @@ AWS Lambda using the serverless framework.
 - `AWS_SECRET_ACCESS_KEY`: The AWS secret.
 - `AWS_ACCESS_KEY_ID`: The AWS access key id.
 
-Check 1Password for the values for our e2e account.
+Check 1Password for the values for our ecosystem-tests account.

--- a/platforms-serverless/vercel-cli/package.json
+++ b/platforms-serverless/vercel-cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "e2e-vercel-cli",
+  "name": "vercel-cli",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/platforms-serverless/vercel-cli/run.sh
+++ b/platforms-serverless/vercel-cli/run.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-cli build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms vercel-cli build'
 yarn
 
 export VERCEL_PROJECT_ID=$VERCEL_API_PROJECT_ID

--- a/platforms-serverless/vercel-node-builder/package.json
+++ b/platforms-serverless/vercel-node-builder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "e2e-vercel-node-builder",
+  "name": "vercel-node-builder",
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",

--- a/platforms-serverless/vercel-node-builder/run.sh
+++ b/platforms-serverless/vercel-node-builder/run.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-node-builder build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms vercel-node-builder build'
 yarn
 
 export VERCEL_PROJECT_ID=$VERCEL_NODE_BUILDER_PROJECT_ID

--- a/platforms-serverless/vercel-with-nextjs/run.sh
+++ b/platforms-serverless/vercel-with-nextjs/run.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-with-nextjs build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms vercel-with-nextjs build'
 yarn
 export VERCEL_PROJECT_ID=$VERCEL_WITH_NEXTJS_PROJECT_ID
 export VERCEL_ORG_ID=$VERCEL_ORG_ID

--- a/platforms-serverless/vercel-with-redwood/run.sh
+++ b/platforms-serverless/vercel-with-redwood/run.sh
@@ -4,7 +4,7 @@ set -eu
 
 yarn policies set-version 1.18.0
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms vercel-with-redwood build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms vercel-with-redwood build'
 
 node patch-package-json.js
 yarn

--- a/platforms/heroku/run.sh
+++ b/platforms/heroku/run.sh
@@ -11,7 +11,7 @@ else
   cp ./prisma/schema-with-node-api.prisma ./prisma/schema.prisma
 fi
 
-export PRISMA_TELEMETRY_INFORMATION='e2e-tests platforms heroku build'
+export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms heroku build'
 yarn install
 yarn prisma generate
 

--- a/test.md
+++ b/test.md
@@ -6,7 +6,7 @@ POSIX-compliant shell script to access the status of this repository.
 ```shell script
 #!/bin/sh
 
-# This script checks if the prisma e2e test workflow passes
+# This script checks if the prisma ecosystem test workflow passes
 # Check the end of the file for usage
 
 check() {
@@ -34,6 +34,6 @@ check() {
 
 # Syntax:
 # check <repo slug> <workflow name>
-check "prisma/prisma-e2e-tests" "test"
+check "prisma/ecosystem-tests" "test"
 
 ```


### PR DESCRIPTION
Change the mentions of `e2e` that are not in project, account or repo names.