### PR TITLE
chore(lambda): use nodejs14.x

### DIFF
--- a/platforms-serverless/lambda/update-code.sh
+++ b/platforms-serverless/lambda/update-code.sh
@@ -4,7 +4,7 @@ set -eux
 
 sh zip.sh
 
-aws lambda update-function-configuration --function-name prisma2-e2e-tests --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 10
+aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs14.x --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 10
 
 aws lambda update-function-code --function-name prisma2-e2e-tests --zip-file "fileb://lambda.zip"
 yarn install

--- a/platforms-serverless/lambda/update-config.sh
+++ b/platforms-serverless/lambda/update-config.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-aws lambda update-function-configuration --function-name prisma2-e2e-tests --handler index.handler --timeout 10
+aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs14.x --handler index.handler --timeout 10


### PR DESCRIPTION
https://docs.aws.amazon.com/lambda/latest/dg/lambda-nodejs.html

Currently, the lambda function is using 12.x and failing since https://github.com/prisma/prisma/pull/14174 was merged and released in internal dev version `4.1.0-dev.74` with
```
2022-07-15T16:55:04.781Z	47f27237-db08-40ba-9fb1-0f9b34489a74	ERROR	Invoke Error 	***"errorType":"ReferenceError","errorMessage":"WeakRef is not defined","stack":["ReferenceError: WeakRef is not defined","    at LibraryEngine.loadEngine (/var/task/node_modules/@prisma/client/runtime/index.js:25229:26)","    at async LibraryEngine.instantiateLibrary (/var/task/node_modules/@prisma/client/runtime/index.js:25190:5)"]***
```

Because `"Runtime": "nodejs12.x",` and WeakRef is only available since 14.6.

Note: v12 was dropped in Prisma 4, current requirements are 14.17.X / 16.X, see https://www.prisma.io/docs/reference/system-requirements