### PR TITLE
Revert "chore(deps): update dependency typescript to v4.8.4"

### DIFF
--- a/community-generators/typegraphql-prisma/package.json
+++ b/community-generators/typegraphql-prisma/package.json
@@ -8,7 +8,7 @@
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
     "typegraphql-prisma": "0.21.5",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/community-generators/typegraphql-prisma/yarn.lock
+++ b/community-generators/typegraphql-prisma/yarn.lock
@@ -3242,10 +3242,10 @@ typegraphql-prisma@0.21.5:
     ts-morph "^15.1.0"
     tslib "^2.4.0"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 undici@5.10.0:
   version "5.10.0"

--- a/core-features/browser-build/package.json
+++ b/core-features/browser-build/package.json
@@ -17,6 +17,6 @@
     "@types/node": "14.18.31",
     "@types/react": "17.0.50",
     "prisma": "4.5.0-dev.9",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/core-features/browser-build/yarn.lock
+++ b/core-features/browser-build/yarn.lock
@@ -231,10 +231,10 @@ tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 use-sync-external-store@1.2.0:
   version "1.2.0"

--- a/core-features/studio/package.json
+++ b/core-features/studio/package.json
@@ -17,6 +17,6 @@
     "jest": "28.1.3",
     "prisma": "4.5.0-dev.9",
     "ts-jest": "28.0.8",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/core-features/studio/yarn.lock
+++ b/core-features/studio/yarn.lock
@@ -2577,10 +2577,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"

--- a/databases/mongodb-atlas-serverless/package.json
+++ b/databases/mongodb-atlas-serverless/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/databases/mongodb-atlas-serverless/yarn.lock
+++ b/databases/mongodb-atlas-serverless/yarn.lock
@@ -120,10 +120,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/databases/mongodb-atlas-sharded/package.json
+++ b/databases/mongodb-atlas-sharded/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/databases/mongodb-atlas-sharded/yarn.lock
+++ b/databases/mongodb-atlas-sharded/yarn.lock
@@ -120,10 +120,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/databases/mongodb-atlas/package.json
+++ b/databases/mongodb-atlas/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/databases/mongodb-atlas/yarn.lock
+++ b/databases/mongodb-atlas/yarn.lock
@@ -120,10 +120,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/databases/mongodb-azure-cosmosdb/package.json
+++ b/databases/mongodb-azure-cosmosdb/package.json
@@ -7,7 +7,7 @@
     "@types/node": "15.12.5",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/databases/mongodb-azure-cosmosdb/yarn.lock
+++ b/databases/mongodb-azure-cosmosdb/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/databases/mongodb-digitalocean/package.json
+++ b/databases/mongodb-digitalocean/package.json
@@ -7,7 +7,7 @@
     "@types/node": "15.12.5",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/databases/mongodb-digitalocean/yarn.lock
+++ b/databases/mongodb-digitalocean/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/dataproxy/cloudflare-workers/package.json
+++ b/dataproxy/cloudflare-workers/package.json
@@ -19,7 +19,7 @@
     "ts-jest": "28.0.8",
     "ts-loader": "8.4.0",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4",
+    "typescript": "4.7.4",
     "webpack": "4.46.0",
     "webpack-cli": "4.10.0"
   }

--- a/dataproxy/cloudflare-workers/yarn.lock
+++ b/dataproxy/cloudflare-workers/yarn.lock
@@ -4619,10 +4619,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 union-value@^1.0.0:
   version "1.0.1"

--- a/dataproxy/nodejs/package.json
+++ b/dataproxy/nodejs/package.json
@@ -14,6 +14,6 @@
     "prisma": "4.5.0-dev.9",
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/dataproxy/nodejs/yarn.lock
+++ b/dataproxy/nodejs/yarn.lock
@@ -2427,10 +2427,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/dataproxy/vercel-cli-serverless-functions/package.json
+++ b/dataproxy/vercel-cli-serverless-functions/package.json
@@ -12,7 +12,7 @@
     "prisma": "4.5.0-dev.9",
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4",
+    "typescript": "4.7.4",
     "vercel": "28.4.6"
   },
   "dependencies": {

--- a/dataproxy/vercel-cli-serverless-functions/yarn.lock
+++ b/dataproxy/vercel-cli-serverless-functions/yarn.lock
@@ -3499,10 +3499,10 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unique-string@^2.0.0:
   version "2.0.0"

--- a/dataproxy/vercel-edge-functions/package.json
+++ b/dataproxy/vercel-edge-functions/package.json
@@ -23,7 +23,7 @@
     "prisma": "4.5.0-dev.9",
     "ts-jest": "28.0.8",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4",
+    "typescript": "4.7.4",
     "vercel": "28.4.6"
   }
 }

--- a/dataproxy/vercel-edge-functions/yarn.lock
+++ b/dataproxy/vercel-edge-functions/yarn.lock
@@ -3883,10 +3883,10 @@ typescript@4.3.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
   integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unique-string@^2.0.0:
   version "2.0.0"

--- a/docker/alpine/package.json
+++ b/docker/alpine/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "start": "node server.js"

--- a/docker/alpine/yarn.lock
+++ b/docker/alpine/yarn.lock
@@ -524,10 +524,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/engines/engine-types/package.json
+++ b/engines/engine-types/package.json
@@ -18,6 +18,6 @@
     "jest": "28.1.3",
     "prisma": "4.5.0-dev.9",
     "ts-jest": "28.0.8",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/engines/engine-types/yarn.lock
+++ b/engines/engine-types/yarn.lock
@@ -2558,10 +2558,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 universalify@^2.0.0:
   version "2.0.0"

--- a/frameworks/nestjs/package.json
+++ b/frameworks/nestjs/package.json
@@ -44,7 +44,7 @@
     "ts-loader": "9.4.1",
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.1.0",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/frameworks/nestjs/yarn.lock
+++ b/frameworks/nestjs/yarn.lock
@@ -4632,15 +4632,15 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+
 typescript@4.8.3:
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
   integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
-
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 universalify@^1.0.0:
   version "1.0.0"

--- a/frameworks/nextjs/package.json
+++ b/frameworks/nextjs/package.json
@@ -17,6 +17,6 @@
     "@types/node": "14.18.31",
     "@types/react": "17.0.50",
     "prisma": "4.5.0-dev.9",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/frameworks/nextjs/yarn.lock
+++ b/frameworks/nextjs/yarn.lock
@@ -231,10 +231,10 @@ tslib@^2.4.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 use-sync-external-store@1.2.0:
   version "1.2.0"

--- a/frameworks/sveltekit/package.json
+++ b/frameworks/sveltekit/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "2.9.1",
     "svelte-preprocess": "4.10.7",
     "tslib": "2.4.0",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "type": "module",
   "dependencies": {

--- a/frameworks/sveltekit/yarn.lock
+++ b/frameworks/sveltekit/yarn.lock
@@ -944,10 +944,10 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 vite@^2.9.0:
   version "2.9.5"

--- a/generic/basic/package.json
+++ b/generic/basic/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/generic/basic/yarn.lock
+++ b/generic/basic/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/libraries/apollo-server/package.json
+++ b/libraries/apollo-server/package.json
@@ -16,6 +16,6 @@
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/libraries/apollo-server/yarn.lock
+++ b/libraries/apollo-server/yarn.lock
@@ -1383,10 +1383,10 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/libraries/express/package.json
+++ b/libraries/express/package.json
@@ -16,6 +16,6 @@
     "@types/express": "4.17.14",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/libraries/express/yarn.lock
+++ b/libraries/express/yarn.lock
@@ -602,10 +602,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/libraries/nexus-schema/package.json
+++ b/libraries/nexus-schema/package.json
@@ -25,7 +25,7 @@
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "prettier": {
     "singleQuote": true,

--- a/libraries/nexus-schema/yarn.lock
+++ b/libraries/nexus-schema/yarn.lock
@@ -1090,10 +1090,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/libraries/type-graphql/package.json
+++ b/libraries/type-graphql/package.json
@@ -19,6 +19,6 @@
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   }
 }

--- a/libraries/type-graphql/yarn.lock
+++ b/libraries/type-graphql/yarn.lock
@@ -1886,10 +1886,10 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@types/node": "14.18.31",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "fetch-retry": "yarn ts-node utils/fetch-retry-and-confirm-version.ts"

--- a/packagers/npm-global/package-lock.json
+++ b/packagers/npm-global/package-lock.json
@@ -7,13 +7,13 @@
       "name": "script",
       "license": "MIT",
       "dependencies": {
-        "@prisma/client": "4.5.0-dev.9"
+        "@prisma/client": "4.4.0-dev.88"
       },
       "devDependencies": {
         "@types/node": "14.18.31",
-        "prisma": "4.5.0-dev.9",
+        "prisma": "4.4.0-dev.88",
         "ts-node": "10.9.1",
-        "typescript": "4.8.4"
+        "typescript": "4.7.4"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -54,12 +54,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.5.0-dev.9.tgz",
-      "integrity": "sha512-6ipAcDFAepeYOb58X6SRo/qQk/Y4UcA0VESxVP69N1vlrLNkeVAmhVaT7QmoL6E6IRvCiTtr3QFKaK38j2IDFw==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.4.0-dev.88.tgz",
+      "integrity": "sha512-DJVTIrDlQeUNr463IKKXO073UAObRC+99nm/KwVs/8JaHZekuw8h2wfFvjsLnssaaMhIVIZv6SptTTDYWPjR7w==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758"
+        "@prisma/engines-version": "4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20"
       },
       "engines": {
         "node": ">=14.17"
@@ -74,16 +74,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0-dev.9.tgz",
-      "integrity": "sha512-EiOKOxxc/HQROGO7BRqt3g1td2/H/UERLIXt5h9u5/2HNCQBWfVGDdTKZboxNtF6RLC7nGN3d3wY9n+XL5W4eg==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.4.0-dev.88.tgz",
+      "integrity": "sha512-H7rEGhvnQk8I710ZSrMPXD/p5Vz1GBd/8AEyPh2DF/fJqhc38/mBcavS1zajw1lEtBG3O2C7BA78k0uB7d+zmA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758.tgz",
-      "integrity": "sha512-GOmve/b1RkaO23R2RByi3PolN46jzgP0x3x8XLWwUW4OTJyaQpoilIv8z1ouBT1whgeYztMydOvXYn47C8NN1A=="
+      "version": "4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20.tgz",
+      "integrity": "sha512-rJ8ARMLweuv2bzs6jsydia5LoOaS0EPaCIw6acySEz3UTJR64RB3ab1AAF6i+DL+nZej3ROnwoswXUm7UacrYA=="
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.8",
@@ -164,13 +164,13 @@
       "dev": true
     },
     "node_modules/prisma": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0-dev.9.tgz",
-      "integrity": "sha512-sfNa4OEfk+M70YOOajxj84t+OYfIg2IKJWYEvX1MzqM9jjpszf15Bb3uDhsrdfMvNJaxeqh4rOVg8E/S90x4kg==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.4.0-dev.88.tgz",
+      "integrity": "sha512-OJjT05+vt7Mqs4jbAN3q9oHh+OzH9o3kxMGdcxiQdYH6GZJIeSLzhdSBaGMn6FukClZnUv6FU4ju0719RXXjug==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.5.0-dev.9"
+        "@prisma/engines": "4.4.0-dev.88"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -285,23 +285,23 @@
       }
     },
     "@prisma/client": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.5.0-dev.9.tgz",
-      "integrity": "sha512-6ipAcDFAepeYOb58X6SRo/qQk/Y4UcA0VESxVP69N1vlrLNkeVAmhVaT7QmoL6E6IRvCiTtr3QFKaK38j2IDFw==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.4.0-dev.88.tgz",
+      "integrity": "sha512-DJVTIrDlQeUNr463IKKXO073UAObRC+99nm/KwVs/8JaHZekuw8h2wfFvjsLnssaaMhIVIZv6SptTTDYWPjR7w==",
       "requires": {
-        "@prisma/engines-version": "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758"
+        "@prisma/engines-version": "4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20"
       }
     },
     "@prisma/engines": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0-dev.9.tgz",
-      "integrity": "sha512-EiOKOxxc/HQROGO7BRqt3g1td2/H/UERLIXt5h9u5/2HNCQBWfVGDdTKZboxNtF6RLC7nGN3d3wY9n+XL5W4eg==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.4.0-dev.88.tgz",
+      "integrity": "sha512-H7rEGhvnQk8I710ZSrMPXD/p5Vz1GBd/8AEyPh2DF/fJqhc38/mBcavS1zajw1lEtBG3O2C7BA78k0uB7d+zmA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758.tgz",
-      "integrity": "sha512-GOmve/b1RkaO23R2RByi3PolN46jzgP0x3x8XLWwUW4OTJyaQpoilIv8z1ouBT1whgeYztMydOvXYn47C8NN1A=="
+      "version": "4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.4.0-65.5a6e984d0af2ae89b66d9dc15f7093b942e48f20.tgz",
+      "integrity": "sha512-rJ8ARMLweuv2bzs6jsydia5LoOaS0EPaCIw6acySEz3UTJR64RB3ab1AAF6i+DL+nZej3ROnwoswXUm7UacrYA=="
     },
     "@tsconfig/node10": {
       "version": "1.0.8",
@@ -370,12 +370,12 @@
       "dev": true
     },
     "prisma": {
-      "version": "4.5.0-dev.9",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.5.0-dev.9.tgz",
-      "integrity": "sha512-sfNa4OEfk+M70YOOajxj84t+OYfIg2IKJWYEvX1MzqM9jjpszf15Bb3uDhsrdfMvNJaxeqh4rOVg8E/S90x4kg==",
+      "version": "4.4.0-dev.88",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.4.0-dev.88.tgz",
+      "integrity": "sha512-OJjT05+vt7Mqs4jbAN3q9oHh+OzH9o3kxMGdcxiQdYH6GZJIeSLzhdSBaGMn6FukClZnUv6FU4ju0719RXXjug==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "4.5.0-dev.9"
+        "@prisma/engines": "4.4.0-dev.88"
       }
     },
     "ts-node": {
@@ -400,9 +400,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/packagers/npm-global/package.json
+++ b/packagers/npm-global/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/packagers/npm-global/yarn.lock
+++ b/packagers/npm-global/yarn.lock
@@ -29,19 +29,19 @@
 
 "@prisma/client@4.5.0-dev.9":
   version "4.5.0-dev.9"
-  resolved "https://registry.npmjs.org/@prisma/client/-/client-4.5.0-dev.9.tgz"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-4.5.0-dev.9.tgz#d9cc7dd103d1170e02a114b0814a0c01570ebb38"
   integrity sha512-6ipAcDFAepeYOb58X6SRo/qQk/Y4UcA0VESxVP69N1vlrLNkeVAmhVaT7QmoL6E6IRvCiTtr3QFKaK38j2IDFw==
   dependencies:
     "@prisma/engines-version" "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758"
 
 "@prisma/engines-version@4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758":
   version "4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758"
-  resolved "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758.tgz"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-4.5.0-1.1345307687fcc8a5d46c472b51cdbc9bea08a758.tgz#5f26978c00753a28f3695c7bda2b63202b2b4cb0"
   integrity sha512-GOmve/b1RkaO23R2RByi3PolN46jzgP0x3x8XLWwUW4OTJyaQpoilIv8z1ouBT1whgeYztMydOvXYn47C8NN1A==
 
 "@prisma/engines@4.5.0-dev.9":
   version "4.5.0-dev.9"
-  resolved "https://registry.npmjs.org/@prisma/engines/-/engines-4.5.0-dev.9.tgz"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-4.5.0-dev.9.tgz#49495205009a2f20cf675931f302c4d889a9b81d"
   integrity sha512-EiOKOxxc/HQROGO7BRqt3g1td2/H/UERLIXt5h9u5/2HNCQBWfVGDdTKZboxNtF6RLC7nGN3d3wY9n+XL5W4eg==
 
 "@tsconfig/node10@^1.0.7":
@@ -101,7 +101,7 @@ make-error@^1.1.1:
 
 prisma@4.5.0-dev.9:
   version "4.5.0-dev.9"
-  resolved "https://registry.npmjs.org/prisma/-/prisma-4.5.0-dev.9.tgz"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.5.0-dev.9.tgz#5bc38709859ad314156e4e14437c38134a47343b"
   integrity sha512-sfNa4OEfk+M70YOOajxj84t+OYfIg2IKJWYEvX1MzqM9jjpszf15Bb3uDhsrdfMvNJaxeqh4rOVg8E/S90x4kg==
   dependencies:
     "@prisma/engines" "4.5.0-dev.9"
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/npm/package.json
+++ b/packagers/npm/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/packagers/npm/yarn.lock
+++ b/packagers/npm/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/pnpm-workspaces-custom-output/package.json
+++ b/packagers/pnpm-workspaces-custom-output/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts",

--- a/packagers/pnpm-workspaces-custom-output/yarn.lock
+++ b/packagers/pnpm-workspaces-custom-output/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/pnpm-workspaces-default-output/package.json
+++ b/packagers/pnpm-workspaces-default-output/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts",

--- a/packagers/pnpm-workspaces-default-output/yarn.lock
+++ b/packagers/pnpm-workspaces-default-output/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/pnpm/package.json
+++ b/packagers/pnpm/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/packagers/pnpm/yarn.lock
+++ b/packagers/pnpm/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/yarn-workspaces/prisma-project/package.json
+++ b/packagers/yarn-workspaces/prisma-project/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9"

--- a/packagers/yarn-workspaces/yarn.lock
+++ b/packagers/yarn-workspaces/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/yarn/package.json
+++ b/packagers/yarn/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/packagers/yarn/yarn.lock
+++ b/packagers/yarn/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/yarn3-without-pnp/package.json
+++ b/packagers/yarn3-without-pnp/package.json
@@ -5,7 +5,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "cmd": "ts-node ./script.ts"

--- a/packagers/yarn3-without-pnp/yarn.lock
+++ b/packagers/yarn3-without-pnp/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/packagers/yarn3-workspaces-pnp/packages/sub-project-1/package.json
+++ b/packagers/yarn3-workspaces-pnp/packages/sub-project-1/package.json
@@ -7,7 +7,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/azure-functions-linux/package.json
+++ b/platforms-serverless/azure-functions-linux/package.json
@@ -8,7 +8,7 @@
     "npm-run-all": "4.1.5",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/azure-functions-linux/yarn.lock
+++ b/platforms-serverless/azure-functions-linux/yarn.lock
@@ -805,10 +805,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unzipper@0.10.10:
   version "0.10.10"

--- a/platforms-serverless/azure-functions-windows/package.json
+++ b/platforms-serverless/azure-functions-windows/package.json
@@ -8,7 +8,7 @@
     "npm-run-all": "4.1.5",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/azure-functions-windows/yarn.lock
+++ b/platforms-serverless/azure-functions-windows/yarn.lock
@@ -805,10 +805,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unzipper@0.10.10:
   version "0.10.10"

--- a/platforms-serverless/firebase-functions/functions/package.json
+++ b/platforms-serverless/firebase-functions/functions/package.json
@@ -19,7 +19,7 @@
     "firebase-functions-test": "2.4.0",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "engines": {
     "node": "14"

--- a/platforms-serverless/firebase-functions/functions/yarn.lock
+++ b/platforms-serverless/firebase-functions/functions/yarn.lock
@@ -1588,10 +1588,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unique-string@^2.0.0:
   version "2.0.0"

--- a/platforms-serverless/gcp-functions/package.json
+++ b/platforms-serverless/gcp-functions/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/gcp-functions/yarn.lock
+++ b/platforms-serverless/gcp-functions/yarn.lock
@@ -125,10 +125,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/platforms-serverless/lambda/package.json
+++ b/platforms-serverless/lambda/package.json
@@ -5,7 +5,7 @@
     "aws-sdk": "2.1204.0",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/lambda/yarn.lock
+++ b/platforms-serverless/lambda/yarn.lock
@@ -505,10 +505,10 @@ ts-node@10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/platforms-serverless/serverless-framework-lambda/package.json
+++ b/platforms-serverless/serverless-framework-lambda/package.json
@@ -6,7 +6,7 @@
     "prisma": "4.5.0-dev.9",
     "serverless": "3.22.0",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "dependencies": {
     "@prisma/client": "4.5.0-dev.9",

--- a/platforms-serverless/serverless-framework-lambda/yarn.lock
+++ b/platforms-serverless/serverless-framework-lambda/yarn.lock
@@ -3247,10 +3247,10 @@ type@^2.7.2:
   resolved "https://registry.yarnpkg.com/type/-/type-2.7.2.tgz#2376a15a3a28b1efa0f5350dcf72d24df6ef98d0"
   integrity sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"

--- a/platforms/codesandbox/package.json
+++ b/platforms/codesandbox/package.json
@@ -20,7 +20,7 @@
     "@types/puppeteer": "5.4.6",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "keywords": []
 }

--- a/platforms/codesandbox/yarn.lock
+++ b/platforms/codesandbox/yarn.lock
@@ -821,10 +821,10 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbzip2-stream@1.4.3:
   version "1.4.3"

--- a/process-managers/pm2/package.json
+++ b/process-managers/pm2/package.json
@@ -6,7 +6,7 @@
     "pm2": "5.2.0",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "start": "node server.js"

--- a/process-managers/pm2/yarn.lock
+++ b/process-managers/pm2/yarn.lock
@@ -1618,10 +1618,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/test-runners/jest-with-multiple-generators/package.json
+++ b/test-runners/jest-with-multiple-generators/package.json
@@ -13,7 +13,7 @@
     "@types/node": "14.18.31",
     "prisma": "4.5.0-dev.9",
     "ts-node": "10.9.1",
-    "typescript": "4.8.4"
+    "typescript": "4.7.4"
   },
   "scripts": {
     "start": "ts-node main.ts",

--- a/test-runners/jest-with-multiple-generators/yarn.lock
+++ b/test-runners/jest-with-multiple-generators/yarn.lock
@@ -2479,10 +2479,10 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,10 +2221,10 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 update-browserslist-db@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Reverts prisma/ecosystem-tests#3052

Somehow Renovate ignored that some tests were failing https://github.com/prisma/ecosystem-tests/pull/3052#issuecomment-1229955024

For example `libraries/apollo-server`