### PR TITLE
test: Node.js v19

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -415,6 +415,7 @@ jobs:
           - 14.17.0 # minimal node version via https://github.com/prisma/prisma/blob/main/packages/client/package.json and minimal minor+patch version of node 14 via https://www.prisma.io/docs/reference/system-requirements
           - 17
           - 18
+          - 19
         clientEngine: ['library', 'binary']
         os: [ubuntu-latest] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Node.js v19 was released on 2022-10-18
https://github.com/nodejs/release#release-schedule

It's on odd release, so it won't turn into a LTS and is not recommended for production but it's better to test to prepare for v20