### PR TITLE
revert: partial of #3226, set TS back to v4.7.4

### DIFF
--- a/libraries/apollo-server/package.json
+++ b/libraries/apollo-server/package.json
@@ -16,6 +16,6 @@
     "prisma": "4.7.0-dev.29",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.9.3"
+    "typescript": "4.7.4"
   }
 }

--- a/libraries/apollo-server/yarn.lock
+++ b/libraries/apollo-server/yarn.lock
@@ -1389,10 +1389,10 @@ type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/libraries/type-graphql/package.json
+++ b/libraries/type-graphql/package.json
@@ -19,6 +19,6 @@
     "prisma": "4.7.0-dev.29",
     "ts-node": "10.9.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "4.9.3"
+    "typescript": "4.7.4"
   }
 }

--- a/libraries/type-graphql/yarn.lock
+++ b/libraries/type-graphql/yarn.lock
@@ -1886,10 +1886,10 @@ type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/platforms-serverless/firebase-functions/functions/package.json
+++ b/platforms-serverless/firebase-functions/functions/package.json
@@ -19,7 +19,7 @@
     "firebase-functions-test": "3.0.0",
     "prisma": "4.7.0-dev.29",
     "ts-node": "10.9.1",
-    "typescript": "4.9.3"
+    "typescript": "4.7.4"
   },
   "engines": {
     "node": "14"

--- a/platforms-serverless/firebase-functions/functions/yarn.lock
+++ b/platforms-serverless/firebase-functions/functions/yarn.lock
@@ -1587,10 +1587,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.9.3:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
-  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unique-string@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Renovate merged the TS update, though tests were failing: https://github.com/prisma/ecosystem-tests/pull/3226

This reverts the update for projects failing.

The failing tests since #3226 was merged are
- libraries (type-graphql, library, ubuntu-latest)
	```
	Interface 'ExecutionResult<TData>' incorrectly extends interface 'ExecutionResult<{ [key: string]: any; }, { [key: string]: any; }>'.
	```
- libraries (apollo-server, library, ubuntu-latest)
	```
	Type 'TArgs' does not satisfy the constraint 'Record<string, any>'.
	```
- platforms-serverless (firebase-functions, library, ubuntu-latest): node_modules/@types/node/globals.d.ts#L85
	```
	Subsequent variable declarations must have the same type. Variable 'AbortSignal' must be of type '*** new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; ***', but here has type '*** new (): AbortSignal; prototype: AbortSignal; ***'.
	```
- platforms-serverless (firebase-functions, binary, ubuntu-latest): node_modules/@types/node/globals.d.ts#L85
	```
	Subsequent variable declarations must have the same type. Variable 'AbortSignal' must be of type '*** new (): AbortSignal; prototype: AbortSignal; abort(reason?: any): AbortSignal; timeout(milliseconds: number): AbortSignal; ***', but here has type '*** new (): AbortSignal; prototype: AbortSignal; ***'.
	```

Problems
- https://github.com/prisma/ecosystem-tests/blob/dev/libraries/type-graphql/package.json is using old dependencies, like `"apollo-server": "2.26.1",` and `"graphql": "15.8.0",`
- https://github.com/prisma/ecosystem-tests/blob/dev/libraries/apollo-server/package.json is using old dependencies like `"apollo-server": "3.11.1",`
- https://github.com/prisma/ecosystem-tests/blob/dev/platforms-serverless/firebase-functions/functions/package.json uses `"firebase-admin": "10.3.0",` should be updated, see issue https://github.com/prisma/ecosystem-tests/pull/2880

About Apollo, see
- https://www.apollographql.com/docs/apollo-server/previous-versions/
- https://www.npmjs.com/package/apollo-server
	> The `apollo-server` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/server` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.