### PR TITLE
ci(gh): replace ubuntu-latest by ubuntu-20.04

### DIFF
--- a/.github/workflows/cancel-workflows.yml
+++ b/.github/workflows/cancel-workflows.yml
@@ -1,11 +1,11 @@
 name: Cancel Workflows
 on:
   workflow_dispatch:
-        
+
 jobs:
   cancel:
     name: 'Cancel Previous Workflow Runs'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 3
     steps:
       # https://github.com/marketplace/actions/cancel-workflow-action

--- a/.github/workflows/check-for-update.yaml
+++ b/.github/workflows/check-for-update.yaml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   check-for-latest-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -29,7 +29,7 @@ jobs:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
   check-for-dev-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -45,7 +45,7 @@ jobs:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
   check-for-patch-dev-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -61,7 +61,7 @@ jobs:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
   check-for-integration-update:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -77,7 +77,7 @@ jobs:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
   report-to-slack-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - check-for-latest-update
       - check-for-dev-update

--- a/.github/workflows/invoke-platforms-lambda-function.yml
+++ b/.github/workflows/invoke-platforms-lambda-function.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   invoke:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     defaults:
       run:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-test-suite-coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     # Ignore if renovate (dependency update) or if triggerred by auto update
     # Needs to be in a string because the colon after chore breaks yaml

--- a/.github/workflows/optional-test.yaml
+++ b/.github/workflows/optional-test.yaml
@@ -19,7 +19,7 @@ on:
     paths-ignore:
       - '*.md'
       - 'renovate.json'
-      
+
 env:
   PRISMA_TELEMETRY_INFORMATION: 'ecosystem-tests optional-test.yaml'
   SLACK_WEBHOOK_URL_WORKFLOWS: ${{ secrets.SLACK_WEBHOOK_URL_OPTIONAL_WORKFLOWS }}
@@ -41,7 +41,7 @@ jobs:
   # Depending on the output we will run some or all tests as fallback
   detect_jobs_to_run:
     name: Detect jobs to run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
     steps:
@@ -61,7 +61,7 @@ jobs:
         run: ./.github/workflows/detect-jobs-to-run.js <<<'${{ steps.files.outputs.all }}'
 
   report-to-slack-success:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - community-generators
       - databases
@@ -76,11 +76,11 @@ jobs:
         run: bash .github/scripts/slack-workflow-status.sh "(Optional tests) :white_check_mark:"
 
   report-to-slack-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - community-generators
       - databases
-      
+
     if: failure() && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/integration' || github.ref == 'refs/heads/patch-dev' || github.ref == 'refs/heads/latest')
     steps:
       - uses: actions/checkout@v3
@@ -97,15 +97,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        generator:
-          [
-            prisma-dbml-generator,
-            typegraphql-prisma,
-            prisma-json-schema-generator,
-            prisma-nestjs-graphql,
-          ]
+        generator: [prisma-dbml-generator, typegraphql-prisma, prisma-json-schema-generator, prisma-nestjs-graphql]
         clientEngine: ['library', 'binary']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     env:
       SKIP_PRISMA_VERSION_CHECK: true # see https://github.com/MichalLytek/typegraphql-prisma/issues/31
@@ -137,7 +131,6 @@ jobs:
         if: failure()
         run: bash .github/slack/notify-failure.sh ${{ github.job }} ${{ matrix.generator }}
 
-
   databases:
     needs: [detect_jobs_to_run]
     if: ${{ fromJson(needs.detect_jobs_to_run.outputs.jobs)['databases'] == true }}
@@ -148,7 +141,7 @@ jobs:
         database:
           - mongodb-azure-cosmosdb
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -6,13 +6,13 @@ jobs:
   rebase:
     name: Rebase
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-    - name: Checkout the latest code
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-    - name: Automatic Rebase
-      uses: cirrus-actions/rebase@1.3.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout the latest code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
   # # which is a common feature in most CI systems but currently not possible with GitHub actions.
   # cleanup-runs:
   #   continue-on-error: true
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-20.04
   # contains(github.actor, 'renovate')
   #   if: (!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/dev' && github.ref != 'refs/heads/integration' && github.ref != 'refs/heads/patch-dev' && github.ref != 'refs/heads/latest')
   #   steps:
@@ -49,7 +49,7 @@ jobs:
   # Depending on the output we will run some or all tests as fallback
   detect_jobs_to_run:
     name: Detect jobs to run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       jobs: ${{ steps.detect.outputs.jobs }}
     steps:
@@ -69,7 +69,7 @@ jobs:
         run: ./.github/workflows/detect-jobs-to-run.js <<<'${{ steps.files.outputs.all }}'
 
   report-to-slack-success:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - dataproxy
       - core-features
@@ -97,7 +97,7 @@ jobs:
         run: bash .github/scripts/slack-workflow-status.sh ":white_check_mark:"
 
   report-to-slack-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - dataproxy
       - core-features
@@ -136,7 +136,7 @@ jobs:
       matrix:
         feature: [pm2]
         clientEngine: [library] # ['library', 'binary']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -182,7 +182,7 @@ jobs:
       matrix:
         feature: [alpine]
         clientEngine: [library, binary]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -236,7 +236,7 @@ jobs:
             generate-client-install-on-sub-project,
           ]
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -282,7 +282,7 @@ jobs:
       matrix:
         feature: [db-seed-commonjs-pkg, db-seed-esm-pkg]
         clientEngine: ['library']
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -327,7 +327,7 @@ jobs:
       fail-fast: false
       matrix:
         feature: [engine-types]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -363,7 +363,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         clientEngine: ['library', 'binary']
     runs-on: ${{ matrix.os }}
 
@@ -417,7 +417,7 @@ jobs:
           - 18
           - 19
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -460,7 +460,7 @@ jobs:
       matrix:
         binary: [pkg]
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -514,7 +514,7 @@ jobs:
           - yarn3-without-pnp
           - yarn3-workspaces-pnp
         clientEngine: [library] #['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -559,7 +559,7 @@ jobs:
           - nextjs
           - sveltekit
         clientEngine: [library] #['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -606,7 +606,7 @@ jobs:
           - codesandbox
           - m1-macstadium
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     concurrency: ${{ github.run_id }}-platforms-${{ matrix.platform }}
 
@@ -674,7 +674,7 @@ jobs:
           - azure-functions-windows
           - serverless-framework-lambda
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
         exclude:
           # Node-API w/ 32 bit Node by default, see https://github.com/prisma/prisma/issues/6905
           - clientEngine: library
@@ -749,7 +749,7 @@ jobs:
           - vercel-with-redwood
           - vercel-with-nextjs
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     concurrency: ${{ github.run_id }}-${{ github.job }}-${{ matrix.platform }}
     env:
@@ -822,7 +822,7 @@ jobs:
           - nodejs-mongodb-itx
           - nodejs-cockroachdb-itx
         clientEngine: ['<dataproxy>'] # value for script logic
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     concurrency: ${{ github.run_id }}-dataproxy-${{ matrix.platform }}
     env:
@@ -888,7 +888,7 @@ jobs:
           - parcel
           - rollup
         clientEngine: [library] #['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -934,7 +934,7 @@ jobs:
           - type-graphql
           - nexus-schema
         clientEngine: [library] #['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -993,7 +993,7 @@ jobs:
           - planetscale
           - cockroach-cloud
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -1100,7 +1100,7 @@ jobs:
         test-runner:
           - jest-with-multiple-generators
         clientEngine: ['library', 'binary']
-        os: [ubuntu-latest] #, windows-latest, macos-latest]
+        os: [ubuntu-20.04] #, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/upgrade-branch-to-version.yaml
+++ b/.github/workflows/upgrade-branch-to-version.yaml
@@ -9,7 +9,7 @@ on:
         required: true
       prismaVersion:
         description: What version of Prisma to upgrade to? (Not used yet!) TODO
-        default: 
+        default:
         required: true
 
 env:
@@ -17,7 +17,7 @@ env:
 
 jobs:
   upgrade-branch-to-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 
@@ -33,7 +33,7 @@ jobs:
           SLACK_WEBHOOK_URL_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_FAILING }}
 
   report-to-slack-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - upgrade-branch-to-version
     if: failure()

--- a/binaries/pkg/README.md
+++ b/binaries/pkg/README.md
@@ -6,4 +6,4 @@ This test tests bundling Prisma CLI code with [`pkg`](https://github.com/vercel/
 
 ### Environment variables
 
-Set the env var `OS` to `ubuntu-latest`, `macos-latest`, `windows-latest` to instruct `pkg` to generate a binary for a specific OS. Note that `test.sh` then should be run on the target OS to test the binary correctly.
+Set the env var `OS` to `ubuntu-20.04`, `macos-latest`, `windows-latest` to instruct `pkg` to generate a binary for a specific OS. Note that `test.sh` then should be run on the target OS to test the binary correctly.

--- a/binaries/pkg/test.sh
+++ b/binaries/pkg/test.sh
@@ -6,7 +6,7 @@ os=""
 filename="./prisma"
 
 case $OS in
-"ubuntu-latest")
+"ubuntu-20.04")
   os="linux"
   ;;
 "macos-latest")


### PR DESCRIPTION
ecosystem-tests are failing because GitHub Actions “ubuntu-latest” changed from Ubuntu 20.04 to 22.04

Note the failures are caused from our expectations on OpenSSL
Which bumped from 1.1.x to 3.0.x on 22.04
```
-----------------------------
-------------- Checking Engines ----------------
+ bash ../../.github/scripts/check-engines-client.sh core-features auto-reconnect
-------------- Checking Generated Client QE Engine --------------
Using env(PRISMA_CLIENT_ENGINE_TYPE): library
Assumed OS: linux
CLIENT_ENGINE_TYPE == library
Library: Enabled
--- ls -lh node_modules/.prisma/client/ ---
total 40M
drwxr-xr-x 2 runner docker 4.0K Dec  1 08:23 deno
-rw-r--r-- 1 runner docker 2.6K Dec  1 08:23 edge.d.ts
-rw-r--r-- 1 runner docker  335 Dec  1 08:23 edge.js
-rw-r--r-- 1 runner docker 4.0K Dec  1 08:24 index-browser.js
-rw-r--r-- 1 runner docker  57K Dec  1 08:24 index.d.ts
-rw-r--r-- 1 runner docker 6.0K Dec  1 08:24 index.js
-rwxr-xr-x 1 runner docker  40M Dec  1 08:23 libquery_engine-debian-openssl-3.0.x.so.node
-rw-r--r-- 1 runner docker  110 Dec  1 08:24 package.json
-rw-r--r-- 1 runner docker  236 Dec  1 08:24 schema.prisma
---
❌ Could not find Query Engine in node_modules/.prisma/client/libquery_engine-debian-openssl-1.1.x.so.node when using linux
```

This is a hotfix to have tests passing before we actually do the upgrade in a separate PR later
