### PR TITLE
try nodejs18

### DIFF
--- a/platforms-serverless/gcp-functions/run.sh
+++ b/platforms-serverless/gcp-functions/run.sh
@@ -24,4 +24,4 @@ yarn tsc
 func="e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$func" > func-tmp.txt
 
-gcloud functions deploy "$func" --runtime nodejs14 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms azure functions linux gcp functions env'
+gcloud functions deploy "$func" --runtime nodejs18 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms azure functions linux gcp functions env'

--- a/platforms-serverless/lambda/create.sh
+++ b/platforms-serverless/lambda/create.sh
@@ -4,4 +4,4 @@ set -eux
 
 sh zip.sh
 
-aws lambda create-function --function-name prisma2-e2e-tests --runtime nodejs14.x --role "$AWS_ROLE" --handler index.handler --zip-file "fileb://lambda.zip"
+aws lambda create-function --function-name prisma2-e2e-tests --runtime nodejs18.x --role "$AWS_ROLE" --handler index.handler --zip-file "fileb://lambda.zip"

--- a/platforms-serverless/lambda/update-code.sh
+++ b/platforms-serverless/lambda/update-code.sh
@@ -4,7 +4,7 @@ set -eux
 
 sh zip.sh
 
-aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs14.x --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 10
+aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs18.x --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 10
 
 aws lambda update-function-code --function-name prisma2-e2e-tests --zip-file "fileb://lambda.zip"
 yarn install

--- a/platforms-serverless/lambda/update-config.sh
+++ b/platforms-serverless/lambda/update-config.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs14.x --handler index.handler --timeout 10
+aws lambda update-function-configuration --function-name prisma2-e2e-tests --runtime nodejs18.x --handler index.handler --timeout 10

--- a/platforms-serverless/serverless-framework-lambda/serverless.yml
+++ b/platforms-serverless/serverless-framework-lambda/serverless.yml
@@ -2,7 +2,7 @@ service: e2e-tests-serverless-lambda
 
 provider:
   name: aws
-  runtime: nodejs14.x
+  runtime: nodejs18.x
   memorySize: 512
   timeout: 10
   versionFunctions: false


### PR DESCRIPTION
LTS, see https://github.com/nodejs/Release

See https://prisma-company.slack.com/archives/C02FNFLDUS3/p1670920800162079

 the google cloud function test assumption failed because
it expected query-engine-debian-openssl-1.1.x  but got query-engine-debian-openssl-3.0.x (which is to be expected, so need to change the test assumption there)