### PR TITLE
ci: add debian-latest-arm64-openssl-1.1.x to docker workflow

### DIFF
--- a/.github/scripts/check-folders.js
+++ b/.github/scripts/check-folders.js
@@ -24,7 +24,6 @@ async function main() {
     'platforms/aws-graviton/code', // aws-graviton doesn't have package.json at root but is included
     'platforms/m1-macstadium/code', // m1-macstadium doesn't have package.json at root but is included
     'docker/_fail-debian-buster-amd64-openssl-1.1.x', // docker/_fail-* is test that fails once run
-    'docker/debian-latest-arm64-openssl-1.1.x', // see https://github.com/prisma/prisma-private/issues/205
   ]
   
   // Jobs in the workflow files that are not relevant and can be skipped

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -187,10 +187,7 @@ jobs:
           - debian-bullseye-amd64-openssl-1.1.x
           - debian-buster-amd64-openssl-1.1.x
           - debian-latest-amd64-openssl-1.1.x
-          
-          # Add back once we solve https://github.com/prisma/prisma-private/issues/205
-          # - debian-latest-arm64-openssl-1.1.x
-          
+          - debian-latest-arm64-openssl-1.1.x
           - opensuse-tumbleweed-amd64-openssl-1.1.x
           - ubuntu-20.04-amd64-openssl-1.1.x
           - ubuntu-22.04-amd64-openssl-3.0.x

--- a/docker/debian-latest-arm64-openssl-1.1.x/run.sh
+++ b/docker/debian-latest-arm64-openssl-1.1.x/run.sh
@@ -5,7 +5,7 @@ export DEBUG="*"
 
 yarn install
 
-DOCKER_PLATFORM_ARCH="linux/amd64"
+DOCKER_PLATFORM_ARCH="linux/arm64"
 PRISMA_DOCKER_IMAGE_NAME="prisma-debian-latest-arm64-openssl-1.1.x"
 
 docker buildx build --load \


### PR DESCRIPTION
Closes https://github.com/prisma/prisma-private/issues/205.

As it turns out, the `debian-latest-arm64-openssl-1.1.x` Docker test was failing for `prisma@4.8.0`, but is succeeding for the latest `dev`-version of `prisma`. 🎉