### PR TITLE
fix(packagers): Migrate from deprecated pnpx

### DIFF
--- a/packagers/pnpm/run.sh
+++ b/packagers/pnpm/run.sh
@@ -3,5 +3,5 @@
 set -eu
 
 pnpm install
-pnpx prisma generate
-pnpx prisma -v
+pnpm exec prisma generate
+pnpm exec prisma -v


### PR DESCRIPTION
As highlighted by @janpio in https://github.com/prisma/ecosystem-tests/pull/3348#issuecomment-1372518008, the tests are currently using `pnpx` which has been deprecated. This Pull Request migrates the deprecated `pnpx` usage to the new, supported, `pnpm exec` usage.

This is not marked as a chore because it fixes a bug with the current test implementation.