### PR TITLE
fix(docker): Add docker file version to Dockerfiles 

### DIFF
--- a/docker/_fail-debian-buster-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/_fail-debian-buster-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-buster-slim
 
 WORKDIR /usr/src/app

--- a/docker/alpine-3.16-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/alpine-3.16-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.16
 
 WORKDIR /usr/src/app

--- a/docker/alpine-3.17-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/alpine-3.17-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.17
 
 WORKDIR /usr/src/app

--- a/docker/alpine-latest-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/alpine-latest-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:current-alpine
 
 WORKDIR /usr/src/app

--- a/docker/debian-bullseye-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-bullseye-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-bullseye-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-buster-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-buster-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-buster-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-latest-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-latest-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-latest-arm64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-latest-arm64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM arm64v8/node:lts-slim
 
 WORKDIR /usr/src/app

--- a/docker/opensuse-tumbleweed-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/opensuse-tumbleweed-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM opensuse/tumbleweed:latest
 
 ARG NODE_VERSION="18.12.1"

--- a/docker/ubuntu-20.04-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/ubuntu-20.04-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG UBUNTU_VERSION="20.04"
 
 FROM ubuntu:${UBUNTU_VERSION}

--- a/docker/ubuntu-22.04-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-22.04-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG UBUNTU_VERSION="22.04"
 
 FROM ubuntu:${UBUNTU_VERSION}

--- a/docker/ubuntu-latest-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-latest-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM ubuntu:latest
 
 ARG NODE_VERSION="18.12.1"

--- a/docker/ubuntu-latest-arm64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-latest-arm64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM arm64v8/ubuntu:latest
 
 ARG NODE_VERSION="18.12.1"


### PR DESCRIPTION
Otherwise fails with:
```
$ sh run.sh 
+ export DEBUG=*
+ yarn install
yarn install v1.22.19                                                                                                                                                                                                                                                                                  
warning ../../package.json: No license field                                                                                                                                                                                                                                                           
[1/4] Resolving packages...                                                                                                                                                                                                                                                                            
success Already up-to-date.                                                                                                                                                                                                                                                                            
Done in 0.10s.                                                                                                                                                                                                                                                                                         
+ DOCKER_PLATFORM_ARCH=linux/amd64
+ PRISMA_DOCKER_IMAGE_NAME=prisma-alpine-3.16-amd64-openssl-1.1.x
+ docker buildx build --load --platform=linux/amd64 --build-context app=. --build-context utils=../_utils --build-arg DEBUG=* --build-arg PRISMA_TELEMETRY_INFORMATION=foo --build-arg PRISMA_CLIENT_ENGINE_TYPE=library --build-arg PRISMA_CLI_QUERY_ENGINE_TYPE=library --build-arg CI=true . -t prisma-alpine-3.16-amd64-openssl-1.1.x --progress plain
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 1.00kB done
#1 DONE 0.0s

#2 [internal] load .dockerignore
#2 transferring context: 2B done
#2 DONE 0.0s
error: failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: unsupported frontend capability moby.buildkit.frontend.contexts
2009 v0.8.2-docker /usr/libexec/docker/cli-plugins/docker-buildx buildx build --load --platform=linux/amd64 --build-context app=. --build-context utils=../_utils --build-arg DEBUG=* --build-arg PRISMA_TELEMETRY_INFORMATION=foo --build-arg PRISMA_CLIENT_ENGINE_TYPE=library --build-arg PRISMA_CLI_QUERY_ENGINE_TYPE=library --build-arg CI=true . -t prisma-alpine-3.16-amd64-openssl-1.1.x --progress plain
github.com/grpc-ecosystem/go-grpc-middleware.ChainUnaryClient.func1.1.1
        /go/src/github.com/docker/buildx/vendor/github.com/grpc-ecosystem/go-grpc-middleware/chain.go:72
...
```

Fix via https://github.com/docker/buildx/issues/1124