### PR TITLE
fix(docker): Add docker file version to Dockerfiles

### DIFF
--- a/docker-unsupported/alpine-3.16-arm64-openssl-1.1.x-with-libc/Dockerfile
+++ b/docker-unsupported/alpine-3.16-arm64-openssl-1.1.x-with-libc/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.16
 
 WORKDIR /usr/src/app

--- a/docker-unsupported/alpine-3.16-arm64-openssl-1.1.x/Dockerfile
+++ b/docker-unsupported/alpine-3.16-arm64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.16
 
 WORKDIR /usr/src/app

--- a/docker-unsupported/alpine-3.17-arm64-openssl-3.0.x-with-libc/Dockerfile
+++ b/docker-unsupported/alpine-3.17-arm64-openssl-3.0.x-with-libc/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.17
 
 WORKDIR /usr/src/app

--- a/docker-unsupported/alpine-3.17-arm64-openssl-3.0.x/Dockerfile
+++ b/docker-unsupported/alpine-3.17-arm64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.17
 
 WORKDIR /usr/src/app

--- a/docker-unsupported/debian-buster-amd64-openssl-1.1.x/Dockerfile
+++ b/docker-unsupported/debian-buster-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-buster-slim
 
 WORKDIR /usr/src/app

--- a/docker/almalinux-latest-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/almalinux-latest-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # substitute for centos
 FROM almalinux:latest
 

--- a/docker/almalinux-latest-arm64-openssl-1.1.x/Dockerfile
+++ b/docker/almalinux-latest-arm64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # substitute for centos
 FROM almalinux:latest
 

--- a/docker/alpine-3.16-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/alpine-3.16-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.16
 
 WORKDIR /usr/src/app

--- a/docker/alpine-3.17-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/alpine-3.17-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-alpine3.17
 
 WORKDIR /usr/src/app

--- a/docker/alpine-latest-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/alpine-latest-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:current-alpine
 
 WORKDIR /usr/src/app

--- a/docker/debian-bullseye-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-bullseye-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-bullseye-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-buster-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-buster-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-buster-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-latest-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-latest-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-latest-arm64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-latest-arm64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM arm64v8/node:lts-slim
 
 WORKDIR /usr/src/app

--- a/docker/debian-stretch-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/debian-stretch-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:lts-stretch-slim
 
 WORKDIR /usr/src/app

--- a/docker/opensuse-tumbleweed-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/opensuse-tumbleweed-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM opensuse/tumbleweed:latest
 
 ARG NODE_VERSION="18.12.1"

--- a/docker/redhat-ubi9-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/redhat-ubi9-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM registry.access.redhat.com/ubi9/nodejs-18:latest
 
 WORKDIR /usr/src/app

--- a/docker/ubuntu-20.04-amd64-openssl-1.1.x/Dockerfile
+++ b/docker/ubuntu-20.04-amd64-openssl-1.1.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG UBUNTU_VERSION="20.04"
 
 FROM ubuntu:${UBUNTU_VERSION}

--- a/docker/ubuntu-22.04-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-22.04-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG UBUNTU_VERSION="22.04"
 
 FROM ubuntu:${UBUNTU_VERSION}

--- a/docker/ubuntu-latest-amd64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-latest-amd64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM ubuntu:latest
 
 ARG NODE_VERSION="18.12.1"

--- a/docker/ubuntu-latest-arm64-openssl-3.0.x/Dockerfile
+++ b/docker/ubuntu-latest-arm64-openssl-3.0.x/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM arm64v8/ubuntu:latest
 
 ARG NODE_VERSION="18.12.1"


### PR DESCRIPTION
replaces https://github.com/prisma/ecosystem-tests/pull/3352

Rationale: needed for running Docker Buildx on GitPod, see https://github.com/prisma/ecosystem-tests/pull/3352#issuecomment-1373380442