### PR TITLE
ci(docker): increase timeout_minutes to 20

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -239,7 +239,7 @@ jobs:
         id: run-test
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 10
+          timeout_minutes: 20
           max_attempts: 3
           command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.feature }}
 


### PR DESCRIPTION
[Internal Slack](https://prisma-company.slack.com/archives/CRGDU19K6/p1673978669438969)