### PR TITLE
fix: avoid constraint violation in nestjs test

### DIFF
--- a/frameworks/nestjs/src/app.service.ts
+++ b/frameworks/nestjs/src/app.service.ts
@@ -7,6 +7,8 @@ export class AppService {
   constructor(private prisma: PrismaService) {}
 
   async getHello(): Promise<string> {
+    await this.prisma.user.deleteMany();
+
     const createUser = await this.prisma.user.create({
       data: {
         email: 'alice@prisma.io',
@@ -41,7 +43,7 @@ export class AppService {
     });
 
     // TODO
-    const files = 'TODO'
+    const files = 'TODO';
 
     return JSON.stringify({
       prismaVersion: Prisma.prismaVersion.client,
@@ -50,7 +52,7 @@ export class AppService {
       },
       updateUser,
       deleteUser,
-      files
+      files,
     });
   }
 }


### PR DESCRIPTION
Fix the test failing with "Unique constraint failed on the
fields: (`email`)" if one of the previous runs was
interrupted (e.g. https://github.com/prisma/ecosystem-tests/actions/runs/4411159692/jobs/7729400786).

This commit also contains the Prettier diff in the file.
