### PR TITLE
fix(dataproxy/nodejs-mongodb-itx): fix validation warning that will become an error

### DIFF
--- a/dataproxy/nodejs-mongodb-itx/prisma/schema.prisma
+++ b/dataproxy/nodejs-mongodb-itx/prisma/schema.prisma
@@ -14,7 +14,7 @@ model Post {
   content   String?
   published Boolean @default(false)
   author    User?   @relation(fields: [authorId], references: [id])
-  authorId  String?
+  authorId  String? @db.ObjectId
 }
 
 model User {


### PR DESCRIPTION
`authorId` refers to the `id` field of the `User` model, so their types must match.