### PR TITLE
fix(notify): add retries for slack notifications

### DIFF
--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -166,9 +166,6 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/integra
     emoji=":white_check_mark:"
   fi
 
-  echo "notifying slack channel"
-  node .github/slack/notify.js "prisma@$version: ${emoji} $workflow_link ran (via $commit_link)"
-
   if [ $code -ne 0 ]; then
     export webhook="$SLACK_WEBHOOK_URL_FAILING"
     echo "notifying failing slack channel"

--- a/.github/slack/post.js
+++ b/.github/slack/post.js
@@ -1,11 +1,20 @@
 const { IncomingWebhook } = require('@slack/webhook')
 
-async function post(url, message) {
-  const webhook = new IncomingWebhook(url)
-  await webhook.send({
-    text: message,
-    icon_emoji: ':microscope:',
-  })
+async function post(url, message, retries = 0) {
+  try {
+    const webhook = new IncomingWebhook(url)
+    await webhook.send({
+      text: message,
+      icon_emoji: ':microscope:',
+    })
+  } catch (err) {
+    if (retries <= 3) {
+      await new Promise((r) => setTimeout(r, retries ** 2 * 1000))
+      await post(url, message, retries + 1)
+    } else {
+      throw err
+    }
+  }
 }
 
 module.exports = post

--- a/.github/slack/post.js
+++ b/.github/slack/post.js
@@ -8,8 +8,8 @@ async function post(url, message, retries = 0) {
       icon_emoji: ':microscope:',
     })
   } catch (err) {
-    if (retries <= 3) {
-      await new Promise((r) => setTimeout(r, retries ** 2 * 1000))
+    if (retries <= 4) {
+      await new Promise((r) => setTimeout(r, retries ** 3 * 1000))
       await post(url, message, retries + 1)
     } else {
       throw err


### PR DESCRIPTION
Because tests are finishing faster since the refactor to `pnpm`, we are now hitting rate limits for pushing slack notifications. This PR fixes that by adding a retry with exponential backoff.