### PR TITLE
chore: put back @prisma/instrumentation on dev tag

### DIFF
--- a/dataproxy/nodejs-tracing/package.json
+++ b/dataproxy/nodejs-tracing/package.json
@@ -12,7 +12,7 @@
     "@opentelemetry/sdk-trace-base": "1.13.0",
     "@opentelemetry/semantic-conventions": "1.13.0",
     "@prisma/client": "4.15.0-dev.86",
-    "@prisma/instrumentation": "4.15.0-integration-windows-portability.6"
+    "@prisma/instrumentation": "4.15.0-dev.86"
   },
   "devDependencies": {
     "@jest/globals": "29.5.0",

--- a/dataproxy/nodejs-tracing/pnpm-lock.yaml
+++ b/dataproxy/nodejs-tracing/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@opentelemetry/sdk-trace-base': 1.13.0
   '@opentelemetry/semantic-conventions': 1.13.0
   '@prisma/client': 4.15.0-dev.86
-  '@prisma/instrumentation': 4.15.0-integration-windows-portability.6
+  '@prisma/instrumentation': 4.15.0-dev.86
   '@types/node': 16.18.34
   jest: 29.5.0
   prisma: 4.15.0-dev.86
@@ -24,7 +24,7 @@ dependencies:
   '@opentelemetry/sdk-trace-base': 1.13.0_@opentelemetry+api@1.4.1
   '@opentelemetry/semantic-conventions': 1.13.0
   '@prisma/client': 4.15.0-dev.86_prisma@4.15.0-dev.86
-  '@prisma/instrumentation': 4.15.0-integration-windows-portability.6
+  '@prisma/instrumentation': 4.15.0-dev.86
 
 devDependencies:
   '@jest/globals': 29.5.0
@@ -728,8 +728,8 @@ packages:
     resolution: {integrity: sha512-7VYOdu+NKPr1lXw+WFH5w7K3DQxcm1cZLOZsNpmcv2KhlKz8qUq1QN6a9TbGGrGk6yONS8zsN3GV7fdG3ZIfyA==}
     requiresBuild: true
 
-  /@prisma/instrumentation/4.15.0-integration-windows-portability.6:
-    resolution: {integrity: sha512-inlGf8B1P4v/J7W1nbRws4RB8nafHnJC3JzaVaTpWnSXEsZWvPpHMz7wb1uKCoukqxGPV2GgzVpRVVJ6RzskMg==}
+  /@prisma/instrumentation/4.15.0-dev.86:
+    resolution: {integrity: sha512-r4DdR27rvvWUwfA8FWY+3J4M4s7JCquGWoBBkyuy4nqXiPRR2DrxQdhBcwFEHm/JTQn2Q9ZMfkjhOZYg4Bv3BQ==}
     dependencies:
       '@opentelemetry/api': 1.4.1
       '@opentelemetry/instrumentation': 0.39.1_@opentelemetry+api@1.4.1

--- a/renovate.json
+++ b/renovate.json
@@ -8,13 +8,14 @@
   },
   "dependencyDashboard": true,
   "prConcurrentLimit": 17,
-  "schedule": [
-    "before 7am every weekday",
-    "every weekend"
-  ],
+  "schedule": ["before 7am every weekday", "every weekend"],
   "rebaseWhen": "auto",
   "ignoreDeps": ["prisma", "@prisma/client"],
   "packageRules": [
+    {
+      "matchPackageNames": ["@prisma/instrumentation"],
+      "followTag": "dev"
+    },
     {
       "groupName": ["svelte packages"],
       "matchPackagePatterns": "svelte"
@@ -31,6 +32,10 @@
     {
       "groupName": "jest",
       "packageNames": ["jest", "@types/jest", "ts-jest"]
+    },
+    {
+      "groupName": "Firebase",
+      "matchPackageNames": ["firebase"]
     },
     {
       "groupName": "Webpack 4 - Cloudflare Workers",


### PR DESCRIPTION
make it follow the dev tag only to avoid future issues and group firebase deps