### PR TITLE
chore: replace deprecated fakerjs calls

### DIFF
--- a/dataproxy/nodejs-cockroachdb-itx/test/batch-itx.test.ts
+++ b/dataproxy/nodejs-cockroachdb-itx/test/batch-itx.test.ts
@@ -24,9 +24,9 @@ describe('batch-itx', () => {
     async () => {
       const emails = new Array(batchAmount)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
-      const randomValue = Number(faker.random.numeric(5))
+      const randomValue = Number(faker.string.numeric(5))
 
       const users = await prisma.$transaction(
         async (tx) => {

--- a/dataproxy/nodejs-cockroachdb-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-cockroachdb-itx/test/burst-load/burst-load.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-cockroachdb-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-cockroachdb-itx/test/concurrent/concurrent.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-cockroachdb-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-cockroachdb-itx/test/lots-of-activities.test.ts
@@ -16,7 +16,7 @@ describe('lots-of-activities', () => {
     async () => {
       const emails = new Array(activities)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
       await prisma.$transaction(async (tx) => {
         await Promise.all(

--- a/dataproxy/nodejs-mongodb-itx/test/batch-itx.test.ts
+++ b/dataproxy/nodejs-mongodb-itx/test/batch-itx.test.ts
@@ -20,9 +20,9 @@ describe('batch-itx', () => {
     async () => {
       const emails = new Array(batchAmount)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
-      const randomValue = Number(faker.random.numeric(5))
+      const randomValue = Number(faker.string.numeric(5))
 
       const users = await prisma.$transaction(
         async (tx) => {

--- a/dataproxy/nodejs-mongodb-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-mongodb-itx/test/burst-load/burst-load.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-mongodb-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-mongodb-itx/test/concurrent/concurrent.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-mongodb-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-mongodb-itx/test/lots-of-activities.test.ts
@@ -16,7 +16,7 @@ describe('lots-of-activities', () => {
     async () => {
       const emails = new Array(activities)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
       await prisma.$transaction(async (tx) => {
         await Promise.all(

--- a/dataproxy/nodejs-mysql-itx/test/batch-itx.test.ts
+++ b/dataproxy/nodejs-mysql-itx/test/batch-itx.test.ts
@@ -20,9 +20,9 @@ describe('batch-itx', () => {
     async () => {
       const emails = new Array(batchAmount)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
-      const randomValue = Number(faker.random.numeric(5))
+      const randomValue = Number(faker.string.numeric(5))
 
       const users = await prisma.$transaction(
         async (tx) => {

--- a/dataproxy/nodejs-mysql-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-mysql-itx/test/burst-load/burst-load.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-mysql-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-mysql-itx/test/concurrent/concurrent.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-mysql-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-mysql-itx/test/lots-of-activities.test.ts
@@ -16,7 +16,7 @@ describe('lots-of-activities', () => {
     async () => {
       const emails = new Array(activities)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
       await prisma.$transaction(async (tx) => {
         await Promise.all(

--- a/dataproxy/nodejs-postgresql-itx/test/batch-itx.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/batch-itx.test.ts
@@ -20,7 +20,7 @@ describe('batch-itx', () => {
     async () => {
       const emails = new Array(batchAmount)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
       const randomValue = Number(faker.random.numeric(5))
 

--- a/dataproxy/nodejs-postgresql-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-postgresql-itx/test/burst-load/burst-load.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-postgresql-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-postgresql-itx/test/concurrent/concurrent.js
@@ -9,7 +9,7 @@ const prisma = new PrismaClient()
 
 async function main() {
   const email = faker.internet.email()
-  const title = faker.random.word()
+  const title = faker.lorem.word()
 
   const user = await prisma.$transaction(
     async (tx) => {

--- a/dataproxy/nodejs-postgresql-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/lots-of-activities.test.ts
@@ -16,7 +16,7 @@ describe('lots-of-activities', () => {
     async () => {
       const emails = new Array(activities)
         .fill(null)
-        .map(() => `${faker.random.alphaNumeric(10)}@${faker.random.alphaNumeric(10)}.com`)
+        .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
       await prisma.$transaction(async (tx) => {
         await Promise.all(


### PR DESCRIPTION
It's too many warnings in the logs, see 
https://github.com/prisma/ecosystem-tests/actions/runs/5456637435/jobs/9929761680#step:8:28088

