### PR TITLE
test(node): test 16.14 instead of 16.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -581,7 +581,7 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 16.13
+          - 16.14 # Prisma's minimum is 16.13 but pnpm 8 minimum is 16.14 
           - 16
           - 17
           - 18


### PR DESCRIPTION
```
ERROR: This version of pnpm requires at least Node.js v16.14
The current version of Node.js is v16.13.2
Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
```
https://github.com/prisma/ecosystem-tests/actions/runs/5530755170/jobs/10090588859#step:5:21