### PR TITLE
chore: replace faker.random.numeric() by faker.string.numeric()

### DIFF
--- a/dataproxy/nodejs-postgresql-itx/test/batch-itx.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/batch-itx.test.ts
@@ -27,7 +27,7 @@ describe('batch-itx', () => {
         .fill(null)
         .map(() => `${faker.string.alphanumeric(10)}@${faker.string.alphanumeric(10)}.com`)
 
-      const randomValue = Number(faker.random.numeric(5))
+      const randomValue = Number(faker.string.numeric(5))
 
       const users = await prisma.$transaction(
         async (tx) => {


### PR DESCRIPTION
Avoids the warning in logs
```
 PASS test/batch-itx.test.ts (17.069 s)
  ● Console

    console.warn
      [@faker-js/faker]: faker.random.numeric() is deprecated since v8.0 and will be removed in v9.0. Please use faker.string.numeric() instead.
```
Example: https://github.com/prisma/ecosystem-tests/actions/runs/5745871271/job/15574536094?pr=3735#step:10:553