### PR TITLE
fix(bundlers): adapt webpack browser test

### DIFF
--- a/bundlers/webpack-browser-custom-output/index.test.js
+++ b/bundlers/webpack-browser-custom-output/index.test.js
@@ -1,11 +1,34 @@
 const { PrismaClient } = require('./dist/prismaTest')
+const prisma = new PrismaClient()
 
-test('correctly generates browser bundle for prisma at custom path', async () => {
-  expect.assertions(1)
+describe('Using browser custom output', () => {
+  test('prisma.user.findFirst() should fail', async () => {
+    expect.assertions(1)
 
-  try {
-    await new PrismaClient().user.findFirst()
-  } catch (e) {
-    expect(e.message).toContain('PrismaClient is unable to run in')
-  }
+    try {
+      prisma.user.findFirst()
+    } catch (e) {
+      expect(e.message).toContain('PrismaClient is unable to run in')
+    }
+  })
+
+  test('prisma.queryRaw`...` should fail', async () => {
+    expect.assertions(1)
+
+    try {
+      prisma.$queryRaw`SELECT 1`
+    } catch (e) {
+      expect(e.message).toContain('PrismaClient is unable to run in')
+    }
+  })
+
+  test('When using a client extension it should fail', async () => {
+    expect.assertions(1)
+
+    try {
+      prisma.$extends({})
+    } catch (e) {
+      expect(e.message).toContain('PrismaClient is unable to run in')
+    }
+  })
 })

--- a/bundlers/webpack-browser-custom-output/index.test.js
+++ b/bundlers/webpack-browser-custom-output/index.test.js
@@ -1,7 +1,7 @@
 const { PrismaClient } = require('./dist/prismaTest')
 
 test('correctly generates browser bundle for prisma at custom path', async () => {
-  await expect(new PrismaClient().user.findFirst()).rejects.toThrow(
+  expect(new PrismaClient().user.findFirst()).toThrow(
     expect.objectContaining({
       message: expect.stringContaining('PrismaClient is unable to run in'),
     }),

--- a/bundlers/webpack-browser-custom-output/index.test.js
+++ b/bundlers/webpack-browser-custom-output/index.test.js
@@ -1,9 +1,9 @@
 const { PrismaClient } = require('./dist/prismaTest')
 
 test('correctly generates browser bundle for prisma at custom path', async () => {
-  expect(new PrismaClient().user.findFirst()).toThrow(
-    expect.objectContaining({
-      message: expect.stringContaining('PrismaClient is unable to run in'),
-    }),
-  )
+  try {
+    await new PrismaClient().user.findFirst()
+  } catch (e) {
+    expect(e.message).toContain('PrismaClient is unable to run in')
+  }
 })

--- a/bundlers/webpack-browser-custom-output/index.test.js
+++ b/bundlers/webpack-browser-custom-output/index.test.js
@@ -1,5 +1,9 @@
 const { PrismaClient } = require('./dist/prismaTest')
 
-test('correctly generates browser bundle for prisma at custom path', () => {
-  expect(() => new PrismaClient()).toThrow('PrismaClient is unable to be run in the browser')
+test('correctly generates browser bundle for prisma at custom path', async () => {
+  await expect(new PrismaClient().user.findFirst()).rejects.toThrow(
+    expect.objectContaining({
+      message: expect.stringContaining('PrismaClient is unable to run in'),
+    }),
+  )
 })

--- a/bundlers/webpack-browser-custom-output/index.test.js
+++ b/bundlers/webpack-browser-custom-output/index.test.js
@@ -1,6 +1,8 @@
 const { PrismaClient } = require('./dist/prismaTest')
 
 test('correctly generates browser bundle for prisma at custom path', async () => {
+  expect.assertions(1)
+
   try {
     await new PrismaClient().user.findFirst()
   } catch (e) {


### PR DESCRIPTION
This adapts our previous tests to our new error strategy which only errors on access and not on the constructor anymore.