### PR TITLE
chore(renovate): automergeSchedule before 7am every weekday

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,13 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base", ":noUnscheduledUpdates"],
   "reviewers": ["@Jolg42", "@millsp", "@aqrln", "@SevInf", "@jkomyno"],
+  "schedule": ["before 7am every weekday", "every weekend"],
+  "automergeSchedule": ["before 7am every weekday"],
   "automerge": true,
   "major": {
     "automerge": false
   },
   "dependencyDashboard": true,
   "prConcurrentLimit": 17,
-  "schedule": ["before 7am every weekday", "every weekend"],
   "rebaseWhen": "auto",
   "ignoreDeps": ["prisma", "@prisma/client", "@prisma/instrumentation"],
   "packageRules": [


### PR DESCRIPTION
[skip ci]

This should help to avoid "instant merges" without waiting for tests. (Because our only required job is `detect_jobs_to_run`)

See docs
https://docs.renovatebot.com/configuration-options/#automergeschedule