### PR TITLE
fix(platform-serverless, lambda): incorrect snapshot

### DIFF
--- a/platforms-serverless/lambda/test.ts
+++ b/platforms-serverless/lambda/test.ts
@@ -22,9 +22,9 @@ async function main() {
   const actual = JSON.stringify(original)
   console.log('actual', actual)
   // TODO Update to only expect on engine file after zip script was updated
-  let files = `,"files":["edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
+  let files = `,"files":["deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]`
   if (process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary') {
-    files = `,"files":["edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","query-engine-rhel-openssl-1.0.x","schema.prisma"]`
+    files = `,"files":["deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","query-engine-rhel-openssl-1.0.x","schema.prisma"]`
   }
 
   const expect =


### PR DESCRIPTION
We previously changed this snapshot because we were unsure (Well, I was). After taking a look locally, it turns out this is the proper expected snapshot. For context, the incorrect snapshot might have been happening because of changes in caching and after a pnpm update. If this snapshot is flaky again in the future, we will need to take a look/reconsider our caching strategy.