### PR TITLE
chore: update snapshots for native deps of engines on ARM64

### DIFF
--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/query-engine.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/schema-engine.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/libquery_engine.so.node.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.3
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.3

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/query-engine.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.3
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.3

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-3.0.x/schema-engine.txt
@@ -1,6 +1,8 @@
 ld-linux-aarch64.so.1
+libcrypto.so.3
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
+libssl.so.3

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,2 +1,4 @@
+libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/query-engine.txt
@@ -1,2 +1,4 @@
+libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/schema-engine.txt
@@ -1,2 +1,4 @@
+libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
+libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/libquery_engine.so.node.txt
@@ -1,2 +1,4 @@
+libcrypto.so.3
 libc.so
 libgcc_s.so.1
+libssl.so.3

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/query-engine.txt
@@ -1,2 +1,4 @@
+libcrypto.so.3
 libc.so
 libgcc_s.so.1
+libssl.so.3

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-3.0.x/schema-engine.txt
@@ -1,2 +1,4 @@
+libcrypto.so.3
 libc.so
 libgcc_s.so.1
+libssl.so.3


### PR DESCRIPTION
Engines now dynamically link to OpenSSL on ARM64 as they were supposed
to do by design (except `openssl-1.0.x` targets which still currently
vendor OpenSSL 1.1, just like on x86_64).

Ref: https://github.com/prisma/engine-images/pull/75
