### PR TITLE
maxWait: 20_000

### DIFF
--- a/dataproxy/nodejs-cockroachdb-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-cockroachdb-itx/test/burst-load/burst-load.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-cockroachdb-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-cockroachdb-itx/test/concurrent/concurrent.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-cockroachdb-itx/test/functional.test.ts
+++ b/dataproxy/nodejs-cockroachdb-itx/test/functional.test.ts
@@ -5,7 +5,7 @@ import util from 'util'
 let prisma = new PrismaClient()
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension') {
   prisma = prisma.$extends(withAccelerate()) as any

--- a/dataproxy/nodejs-cockroachdb-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-cockroachdb-itx/test/lots-of-activities.test.ts
@@ -6,7 +6,7 @@ import { config } from '../config'
 const activities = config['lots-of-activities'].amount
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension' || process.env.DATAPROXY_FLAVOR === 'DP2') {
   timeouts = accelerateWithExtensionTimeouts

--- a/dataproxy/nodejs-mongodb-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-mongodb-itx/test/burst-load/burst-load.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-mongodb-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-mongodb-itx/test/concurrent/concurrent.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-mongodb-itx/test/functional.test.ts
+++ b/dataproxy/nodejs-mongodb-itx/test/functional.test.ts
@@ -5,7 +5,7 @@ import util from 'util'
 let prisma = new PrismaClient()
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension') {
   prisma = prisma.$extends(withAccelerate()) as any

--- a/dataproxy/nodejs-mongodb-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-mongodb-itx/test/lots-of-activities.test.ts
@@ -6,7 +6,7 @@ import { config } from '../config'
 const activities = config['lots-of-activities'].amount
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension' || process.env.DATAPROXY_FLAVOR === 'DP2') {
   timeouts = accelerateWithExtensionTimeouts

--- a/dataproxy/nodejs-mysql-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-mysql-itx/test/burst-load/burst-load.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-mysql-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-mysql-itx/test/concurrent/concurrent.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-mysql-itx/test/functional.test.ts
+++ b/dataproxy/nodejs-mysql-itx/test/functional.test.ts
@@ -5,7 +5,7 @@ import util from 'util'
 let prisma = new PrismaClient()
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension') {
   prisma = prisma.$extends(withAccelerate()) as any

--- a/dataproxy/nodejs-mysql-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-mysql-itx/test/lots-of-activities.test.ts
@@ -6,7 +6,7 @@ import { config } from '../config'
 const activities = config['lots-of-activities'].amount
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension' || process.env.DATAPROXY_FLAVOR === 'DP2') {
   timeouts = accelerateWithExtensionTimeouts

--- a/dataproxy/nodejs-postgresql-itx/test/burst-load/burst-load.js
+++ b/dataproxy/nodejs-postgresql-itx/test/burst-load/burst-load.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-postgresql-itx/test/concurrent/concurrent.js
+++ b/dataproxy/nodejs-postgresql-itx/test/concurrent/concurrent.js
@@ -38,7 +38,7 @@ async function main() {
       return user
     },
     {
-      maxWait: 120_000,
+      maxWait: 20_000,
       timeout: accelerateItxMax,
     },
   )

--- a/dataproxy/nodejs-postgresql-itx/test/functional.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/functional.test.ts
@@ -5,7 +5,7 @@ import util from 'util'
 let prisma = new PrismaClient()
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension') {
   prisma = prisma.$extends(withAccelerate()) as any

--- a/dataproxy/nodejs-postgresql-itx/test/lots-of-activities.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/lots-of-activities.test.ts
@@ -6,7 +6,7 @@ import { config } from '../config'
 const activities = config['lots-of-activities'].amount
 let timeouts = { maxWait: 2_000, timeout: 5_000 }
 const accelerateItxMax = 15_000
-let accelerateWithExtensionTimeouts = { maxWait: 120_000, timeout: accelerateItxMax }
+let accelerateWithExtensionTimeouts = { maxWait: 20_000, timeout: accelerateItxMax }
 
 if (process.env.DATAPROXY_FLAVOR === 'DP2+Extension' || process.env.DATAPROXY_FLAVOR === 'DP2') {
   timeouts = accelerateWithExtensionTimeouts


### PR DESCRIPTION
Follows https://github.com/prisma/ecosystem-tests/pull/3928

maxWait is "high" so the test can be reliable, waiting for a connection to be free for doing an itx.