### PR TITLE
ci(test.yaml): increase timeout for driver-adapters to 30min

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1150,7 +1150,7 @@ jobs:
     needs: [detect_jobs_to_run]
     if: ${{ fromJson(needs.detect_jobs_to_run.outputs.jobs)['driver-adapters'] == true }}
 
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
See https://prisma-company.slack.com/archives/CRGDU19K6/p1695736895874389

Because of queing on Vercel side