### PR TITLE
fix(turso): Use "web" package on Lambda

### DIFF
--- a/driver-adapters/turso-lambda-basic/index.js
+++ b/driver-adapters/turso-lambda-basic/index.js
@@ -1,5 +1,5 @@
 const { Prisma, PrismaClient } = require('@prisma/client')
-const { createClient } = require('@libsql/client')
+const { createClient } = require('@libsql/client/web')
 const { PrismaLibSQL } = require('@prisma/adapter-libsql')
 
 const connectionString = process.env.DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -20,5 +20,5 @@ cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-turso-lambda-basic --runtime nodejs18.x --environment "Variables={DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-turso-lambda-basic --runtime nodejs18.x --environment "Variables={DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL,DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-turso-lambda-basic --zip-file "fileb://lambda.zip"


### PR DESCRIPTION
Normal package `@libsql/client` does not work on Lambda (via our setup):
```
{
    "errorType": "Runtime.ImportModuleError",
    "errorMessage": "Error: Cannot find module '@libsql/linux-x64-gnu'\nRequire stack:\n- /var/task/index.js\n- /var/runtime/index.mjs",
    "stack": [
        "Runtime.ImportModuleError: Error: Cannot find module '@libsql/linux-x64-gnu'",
        "Require stack:",
        "- /var/task/index.js",
        "- /var/runtime/index.mjs",
        "    at _loadUserApp (file:///var/runtime/index.mjs:1061:17)",
        "    at async UserFunction.js.module.exports.load (file:///var/runtime/index.mjs:1093:21)",
        "    at async start (file:///var/runtime/index.mjs:1256:23)",
        "    at async file:///var/runtime/index.mjs:1262:1"
    ]
}
```

Switching to `@libsql/client/web` makes it work.