### PR TITLE
fix: ignore yarn4 error as we only use 3.x

### DIFF
--- a/packagers/yarn3-without-pnp/run.sh
+++ b/packagers/yarn3-without-pnp/run.sh
@@ -5,7 +5,7 @@ set -eux
 # YARN_IGNORE_NODE=1 is needed to ignore the Node.js version 
 # since the latest version needs v18+
 # TODO: remove once we switched to v18
-YARN_IGNORE_NODE=1 
+export YARN_IGNORE_NODE=1 
 
 # We must set yarn to berry first
 # if not this error will show up later

--- a/packagers/yarn3-without-pnp/run.sh
+++ b/packagers/yarn3-without-pnp/run.sh
@@ -2,9 +2,6 @@
 
 set -eux
 
-# Set Yarn to berry
-yarn set version berry
-
 # To set Yarn to 3.x
 yarn set version 3.x
 

--- a/packagers/yarn3-without-pnp/run.sh
+++ b/packagers/yarn3-without-pnp/run.sh
@@ -2,6 +2,13 @@
 
 set -eux
 
+# We must set yarn to berry first
+# if not this error will show up later
+# error An unexpected error occurred: "Release not found: 3.x".
+# YARN_IGNORE_NODE=1 is needed to ignore the Node.js version 
+# since the latest version needs v18+
+YARN_IGNORE_NODE=1 yarn set version berry
+
 # To set Yarn to 3.x
 yarn set version 3.x
 

--- a/packagers/yarn3-without-pnp/run.sh
+++ b/packagers/yarn3-without-pnp/run.sh
@@ -2,12 +2,15 @@
 
 set -eux
 
+# YARN_IGNORE_NODE=1 is needed to ignore the Node.js version 
+# since the latest version needs v18+
+# TODO: remove once we switched to v18
+YARN_IGNORE_NODE=1 
+
 # We must set yarn to berry first
 # if not this error will show up later
 # error An unexpected error occurred: "Release not found: 3.x".
-# YARN_IGNORE_NODE=1 is needed to ignore the Node.js version 
-# since the latest version needs v18+
-YARN_IGNORE_NODE=1 yarn set version berry
+yarn set version berry
 
 # To set Yarn to 3.x
 yarn set version 3.x

--- a/packagers/yarn3-workspaces-pnp/run.sh
+++ b/packagers/yarn3-workspaces-pnp/run.sh
@@ -2,6 +2,16 @@
 
 set -eu
 
+# YARN_IGNORE_NODE=1 is needed to ignore the Node.js version 
+# since the latest version needs v18+
+# TODO: remove once we switched to v18
+export YARN_IGNORE_NODE=1 
+
+# We must set yarn to berry first
+# if not this error will show up later
+# error An unexpected error occurred: "Release not found: 3.x".
+yarn set version berry
+
 # To set Yarn to 3.x
 yarn set version 3.x
 

--- a/packagers/yarn3-workspaces-pnp/run.sh
+++ b/packagers/yarn3-workspaces-pnp/run.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-# Set Yarn to berry
-yarn set version berry
-
 # To set Yarn to 3.x
 yarn set version 3.x
 


### PR DESCRIPTION
see https://github.com/prisma/ecosystem-tests/actions/runs/6622479480/job/17988106646#step:8:405
```
+ yarn set version berry
warning ../../package.json: No license field
➤ YN0000: Retrieving https://repo.yarnpkg.com/4.0.0/packages/yarnpkg-cli/bin/yarn.js
➤ YN0001: Error: Invalid semver version. yarn --version returned:
Usage Error: This tool requires a Node version compatible with >=18.12.0 (got 16.20.2). Upgrade Node, or set `YARN_IGNORE_NODE=1` in your environment.
```