### PR TITLE
ci(renovate): Enable config migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "dependencyDashboard": true,
   "prConcurrentLimit": 17,
   "rebaseWhen": "auto",
+  "configMigration": true,
   "ignoreDeps": ["prisma", "@prisma/client", "@prisma/instrumentation"],
   "packageRules": [
     {


### PR DESCRIPTION
With this configuration Renovate should open PRs to improve the configuration itself, so that we never use outdated keys or similar (as we do right now with packageNames, which was migrated to matchPackageNames)

see docs.renovatebot.com/configuration-options/#configmigration