### PR TITLE
test(engine-native-deps): adapt test

### DIFF
--- a/engines/engine-native-deps/test.mjs
+++ b/engines/engine-native-deps/test.mjs
@@ -3,10 +3,9 @@ import * as fs from 'node:fs/promises'
 
 import 'zx/globals'
 
-const clientPath = await import.meta.resolve('@prisma/client')
-const versionPath = await import.meta.resolve('@prisma/engines-version', clientPath)
-const { enginesVersion } = await import(versionPath)
+import { Prisma } from '@prisma/client'
 
+const enginesVersion = Prisma.prismaVersion.engine
 const update = process.argv.includes('--update')
 
 const allEngines = ['query-engine', 'schema-engine', 'libquery_engine.so.node']


### PR DESCRIPTION
`@prisma/engines-version` is not a dependency of `@prisma/client` anymore, as it is bundled (always was), so it was removed from the dependencies. The test is adapted in order to reflect that.