### PR TITLE
chore(dataproxy): remove DP1 code

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1407,7 +1407,7 @@ jobs:
         if: failure()
         run: bash .github/slack/notify-failure.sh ${{ github.job }} ${{ matrix.combo }}
 
-  # TODO databases are shared between the steps (DP1, DP2, DP2+Accelerate), so we run them in sequence
+  # TODO databases are shared between the steps (DP2, DP2+Accelerate), so we run them in sequence
   # it would be great if we could run them in parallel by letting them use the db provided by E2E
   dataproxy:
     needs: [detect_jobs_to_run]
@@ -1512,28 +1512,6 @@ jobs:
           ITX_PDP_POSTGRESQL: ${{ secrets.DP2_ITX_PDP_POSTGRESQL }}
           ITX_PDP_COCKROACHDB_DATABASE_URL: ${{ secrets.ITX_PDP_COCKROACHDB_DATABASE_URL }}
           ITX_PDP_COCKROACHDB: ${{ secrets.DP2_ITX_PDP_COCKROACHDB }}
-
-      # see above why this is not a matrix for each DP variant
-      - name: test legacy Data Proxy (DP1) ${{ matrix.platform }}
-        if: false
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.platform }}
-        env:
-          DATAPROXY_FLAVOR: 'DP1'
-          PRISMA_GENERATE_FLAG: '--data-proxy'
-          DATAPROXY_COMMON_URL: ${{ secrets.DATAPROXY_COMMON_URL }}
-          ITX_PDP_MONGODB_DATABASE_URL: ${{ secrets.ITX_PDP_MONGODB_DATABASE_URL }}
-          ITX_PDP_MONGODB: ${{ secrets.ITX_PDP_MONGODB }}
-          ITX_PDP_MYSQL_DATABASE_URL: ${{ secrets.ITX_PDP_MYSQL_DATABASE_URL }}
-          ITX_PDP_MYSQL: ${{ secrets.ITX_PDP_MYSQL }}
-          ITX_PDP_POSTGRESQL_DATABASE_URL: ${{ secrets.ITX_PDP_POSTGRESQL_DATABASE_URL }}
-          ITX_PDP_POSTGRESQL: ${{ secrets.ITX_PDP_POSTGRESQL }}
-          ITX_PDP_COCKROACHDB_DATABASE_URL: ${{ secrets.ITX_PDP_COCKROACHDB_DATABASE_URL }}
-          ITX_PDP_COCKROACHDB: ${{ secrets.ITX_PDP_COCKROACHDB }}
 
       - name: notify-slack
         if: failure()

--- a/dataproxy/nodejs-cockroachdb-itx/test/long-running.test.ts
+++ b/dataproxy/nodejs-cockroachdb-itx/test/long-running.test.ts
@@ -5,11 +5,8 @@ import util from 'util'
 import { prismaClientVersion } from './utils'
 import { config } from '../config'
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
 const sleep = util.promisify(setTimeout)
 const accelerateItxMax = 15_000
-const dp1ItxTimeout = 120_000
-const isDP1 = process.env.DATAPROXY_FLAVOR === 'DP1'
 
 describe('long-running', () => {
   let prisma: PrismaClient
@@ -36,7 +33,7 @@ describe('long-running', () => {
     })
   })
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should throw an error on long-running itx that sets a timeout limit over the limit',
     async () => {
       const email = faker.internet.email()
@@ -68,7 +65,7 @@ describe('long-running', () => {
     config.globalTimeout,
   )
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should run a transaction for ~+13s and then still succeed',
     async () => {
       const email = faker.internet.email()
@@ -86,38 +83,6 @@ describe('long-running', () => {
         {
           maxWait: 20_000,
           timeout: accelerateItxMax,
-        },
-      )
-
-      const found = await prisma.user.findFirst({
-        where: {
-          id: user.id,
-        },
-      })
-
-      expect(found?.email).toEqual(email)
-    },
-    config.globalTimeout,
-  )
-
-  testIf(isDP1)(
-    'DP1 only: should run a transaction for 1 min and then still succeed',
-    async () => {
-      const email = faker.internet.email()
-
-      const user = await prisma.$transaction(
-        async (tx) => {
-          await sleep(dp1ItxTimeout - 5_000)
-
-          return tx.user.create({
-            data: {
-              email,
-            },
-          })
-        },
-        {
-          maxWait: 20_000,
-          timeout: dp1ItxTimeout,
         },
       )
 

--- a/dataproxy/nodejs-mongodb-itx/test/long-running.test.ts
+++ b/dataproxy/nodejs-mongodb-itx/test/long-running.test.ts
@@ -5,11 +5,8 @@ import util from 'util'
 import { prismaClientVersion } from './utils'
 import { config } from '../config'
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
 const sleep = util.promisify(setTimeout)
 const accelerateItxMax = 15_000
-const dp1ItxTimeout = 120_000
-const isDP1 = process.env.DATAPROXY_FLAVOR === 'DP1'
 
 describe('long-running', () => {
   let prisma: PrismaClient
@@ -36,7 +33,7 @@ describe('long-running', () => {
     })
   })
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should throw an error on long-running itx that sets a timeout limit over the limit',
     async () => {
       const email = faker.internet.email()
@@ -68,7 +65,7 @@ describe('long-running', () => {
     config.globalTimeout,
   )
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should run a transaction for ~+13s and then still succeed',
     async () => {
       const email = faker.internet.email()
@@ -86,38 +83,6 @@ describe('long-running', () => {
         {
           maxWait: 20_000,
           timeout: accelerateItxMax,
-        },
-      )
-
-      const found = await prisma.user.findFirst({
-        where: {
-          id: user.id,
-        },
-      })
-
-      expect(found?.email).toEqual(email)
-    },
-    config.globalTimeout,
-  )
-
-  testIf(isDP1)(
-    'DP1 only: should run a transaction for 1 min and then still succeed',
-    async () => {
-      const email = faker.internet.email()
-
-      const user = await prisma.$transaction(
-        async (tx) => {
-          await sleep(dp1ItxTimeout - 5_000)
-
-          return tx.user.create({
-            data: {
-              email,
-            },
-          })
-        },
-        {
-          maxWait: 20_000,
-          timeout: dp1ItxTimeout,
         },
       )
 

--- a/dataproxy/nodejs-mysql-itx/test/long-running.test.ts
+++ b/dataproxy/nodejs-mysql-itx/test/long-running.test.ts
@@ -5,11 +5,8 @@ import util from 'util'
 import { prismaClientVersion } from './utils'
 import { config } from '../config'
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
 const sleep = util.promisify(setTimeout)
 const accelerateItxMax = 15_000
-const dp1ItxTimeout = 120_000
-const isDP1 = process.env.DATAPROXY_FLAVOR === 'DP1'
 
 describe('long-running', () => {
   let prisma: PrismaClient
@@ -36,7 +33,7 @@ describe('long-running', () => {
     })
   })
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should throw an error on long-running itx that sets a timeout limit over the limit',
     async () => {
       const email = faker.internet.email()
@@ -68,7 +65,7 @@ describe('long-running', () => {
     config.globalTimeout,
   )
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should run a transaction for ~+13s and then still succeed',
     async () => {
       const email = faker.internet.email()
@@ -86,38 +83,6 @@ describe('long-running', () => {
         {
           maxWait: 20_000,
           timeout: accelerateItxMax,
-        },
-      )
-
-      const found = await prisma.user.findFirst({
-        where: {
-          id: user.id,
-        },
-      })
-
-      expect(found?.email).toEqual(email)
-    },
-    config.globalTimeout,
-  )
-
-  testIf(isDP1)(
-    'DP1 only: should run a transaction for 1 min and then still succeed',
-    async () => {
-      const email = faker.internet.email()
-
-      const user = await prisma.$transaction(
-        async (tx) => {
-          await sleep(dp1ItxTimeout - 5_000)
-
-          return tx.user.create({
-            data: {
-              email,
-            },
-          })
-        },
-        {
-          maxWait: 20_000,
-          timeout: dp1ItxTimeout,
         },
       )
 

--- a/dataproxy/nodejs-postgresql-itx/test/long-running.test.ts
+++ b/dataproxy/nodejs-postgresql-itx/test/long-running.test.ts
@@ -5,11 +5,8 @@ import util from 'util'
 import { prismaClientVersion } from './utils'
 import { config } from '../config'
 
-const testIf = (condition: boolean) => (condition ? test : test.skip)
 const sleep = util.promisify(setTimeout)
 const accelerateItxMax = 15_000
-const dp1ItxTimeout = 120_000
-const isDP1 = process.env.DATAPROXY_FLAVOR === 'DP1'
 
 describe('long-running', () => {
   let prisma: PrismaClient
@@ -36,7 +33,7 @@ describe('long-running', () => {
     })
   })
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should throw an error on long-running itx that sets a timeout limit over the limit',
     async () => {
       const email = faker.internet.email()
@@ -68,7 +65,7 @@ describe('long-running', () => {
     config.globalTimeout,
   )
 
-  testIf(!isDP1)(
+  test(
     'accelerate only: should run a transaction for ~+13s and then still succeed',
     async () => {
       const email = faker.internet.email()
@@ -86,38 +83,6 @@ describe('long-running', () => {
         {
           maxWait: 20_000,
           timeout: accelerateItxMax,
-        },
-      )
-
-      const found = await prisma.user.findFirst({
-        where: {
-          id: user.id,
-        },
-      })
-
-      expect(found?.email).toEqual(email)
-    },
-    config.globalTimeout,
-  )
-
-  testIf(isDP1)(
-    'DP1 only: should run a transaction for 1 min and then still succeed',
-    async () => {
-      const email = faker.internet.email()
-
-      const user = await prisma.$transaction(
-        async (tx) => {
-          await sleep(dp1ItxTimeout - 5_000)
-
-          return tx.user.create({
-            data: {
-              email,
-            },
-          })
-        },
-        {
-          maxWait: 20_000,
-          timeout: dp1ItxTimeout,
         },
       )
 


### PR DESCRIPTION
This PR deletes the DP1 tests/code as DataProxy 1 is now [decommissioned](https://prisma-company.slack.com/archives/C02C34KRHBQ/p1704716449110369).
