### PR TITLE
test(driver-adapters): custom output

### DIFF
--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -67,6 +67,17 @@ fi
 echo "$ cd $dir/$project"
 cd "$dir/$project"
 
+# if FORCE_CUSTOM_OUTPUT is set, we execute 3 commands that will turn the project into a custom output project
+if [ -n "$FORCE_CUSTOM_OUTPUT" ]; then
+  echo "-----------------------------"
+  echo ""
+  echo "FORCE_CUSTOM_OUTPUT=$FORCE_CUSTOM_OUTPUT, executing 3 commands to turn the project into a custom output project"
+  echo ""
+  find . -name "*.js" | grep -v node_modules | grep -v test | xargs sed -i "s/@prisma\/client/db/g"
+  find . -name "*.prisma" | grep -v node_modules | xargs sed -i '/generator client {/a output = "client"'
+  find . -name "package.json" | grep -v node_modules | xargs sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
+fi
+
 if [ -f "prepare.sh" ]; then
   echo "-----------------------------"
   echo ""

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -67,15 +67,16 @@ fi
 echo "$ cd $dir/$project"
 cd "$dir/$project"
 
-# if FORCE_CUSTOM_OUTPUT is set, we execute 3 commands that will turn the project into a custom output project
+# if FORCE_CUSTOM_OUTPUT is set, we execute commands that will turn the project into a custom output project
 if [ -n "${FORCE_CUSTOM_OUTPUT+x}" ]; then
   echo "-----------------------------"
   echo ""
-  echo "FORCE_CUSTOM_OUTPUT=$FORCE_CUSTOM_OUTPUT, executing 3 commands to turn the project into a custom output project"
+  echo "FORCE_CUSTOM_OUTPUT=$FORCE_CUSTOM_OUTPUT, executing commands to turn the project into a custom output project"
   echo ""
-  find . -name "*.js" | grep -v node_modules | grep -v test | xargs sed -i "s/@prisma\/client/db/g"
-  find . -name "*.prisma" | grep -v node_modules | xargs sed -i '/generator client {/a output = "client"'
-  find . -name "package.json" | grep -v node_modules | xargs sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
+  find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
+  find . -name "*.prisma" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i '/generator client {/a output = "client"'
+  find . -name "package.json" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
+  bash ../../update-locks.sh
 fi
 
 if [ -f "prepare.sh" ]; then

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -67,11 +67,11 @@ fi
 echo "$ cd $dir/$project"
 cd "$dir/$project"
 
-# if FORCE_CUSTOM_OUTPUT is set, we execute commands that will turn the project into a custom output project
-if [ -n "${FORCE_CUSTOM_OUTPUT+x}" ]; then
+# if FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT is set, we execute commands that will turn the project into a custom output project
+if [ -n "${FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT+x}" ]; then
   echo "-----------------------------"
   echo ""
-  echo "FORCE_CUSTOM_OUTPUT=$FORCE_CUSTOM_OUTPUT, executing commands to turn the project into a custom output project"
+  echo "FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT=$FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT, executing commands to turn the project into a custom output project"
   echo ""
   find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
   find . -name "*.prisma" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i '/generator client {/a output = "client"'

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -76,7 +76,7 @@ if [ -n "${FORCE_CUSTOM_OUTPUT+x}" ]; then
   find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
   find . -name "*.prisma" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i '/generator client {/a output = "client"'
   find . -name "package.json" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
-  bash ../../update-locks.sh
+  bash ../../scripts/update-locks.sh
 fi
 
 if [ -f "prepare.sh" ]; then

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -68,7 +68,7 @@ echo "$ cd $dir/$project"
 cd "$dir/$project"
 
 # if FORCE_CUSTOM_OUTPUT is set, we execute 3 commands that will turn the project into a custom output project
-if [ -n "$FORCE_CUSTOM_OUTPUT" ]; then
+if [ -n "${FORCE_CUSTOM_OUTPUT+x}" ]; then
   echo "-----------------------------"
   echo ""
   echo "FORCE_CUSTOM_OUTPUT=$FORCE_CUSTOM_OUTPUT, executing 3 commands to turn the project into a custom output project"

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -73,10 +73,10 @@ if [ -n "${FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT+x}" ]; then
   echo ""
   echo "FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT=$FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT, executing commands to turn the project into a custom output project"
   echo ""
-  find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
-  find . -name "*.mjs" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
-  find . -name "*.prisma" | grep -v node_modules | xargs sed -i 's/provider\s*=\s*"prisma-client-js"/&\noutput = "client"/g'
-  find . -name "package.json" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i 's/"dependencies": {/&\n"db": "link:.\/prisma\/client",/g'
+  find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 -r sed -i "s/@prisma\/client/db/g"
+  find . -name "*.mjs" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 -r sed -i "s/@prisma\/client/db/g"
+  find . -name '*.prisma' ! -path '*/node_modules/*' -print0 | xargs -0 -r sed -i 's/provider\s*=\s*"prisma-client-js"/&\noutput = "client"/g'
+  find . -name "package.json" ! -path "*/node_modules/*" -print0 | xargs -0 -r sed -i 's/"dependencies": {/&\n"db": "link:.\/prisma\/client",/g'
   bash ../../scripts/update-locks.sh
   
   # this adds some level of safety to ensure that js files were at least modified as one would expect

--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -74,12 +74,13 @@ if [ -n "${FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT+x}" ]; then
   echo "FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT=$FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT, executing commands to turn the project into a custom output project"
   echo ""
   find . -name "*.js" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
+  find . -name "*.mjs" ! -path "*/node_modules/*" ! -name "*test*" -print0 | xargs -0 sed -i "s/@prisma\/client/db/g"
   find . -name "*.prisma" | grep -v node_modules | xargs sed -i 's/provider\s*=\s*"prisma-client-js"/&\noutput = "client"/g'
   find . -name "package.json" ! -path "*/node_modules/*" -print0 | xargs -0 sed -i 's/"dependencies": {/&\n"db": "link:.\/prisma\/client",/g'
   bash ../../scripts/update-locks.sh
   
   # this adds some level of safety to ensure that js files were at least modified as one would expect
-  if [[ $(git status --porcelain | grep "$dir/$project" | grep -c ".js$") -gt 0 ]];
+  if [[ $(git status --porcelain | grep "$dir/$project" | grep -Ec ".m?js$") -gt 0 ]];
   then
     echo "javascript files were correctly modified for the custom output project"
   else

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1383,9 +1383,7 @@ jobs:
           max_attempts: 1
           retry_wait_seconds: 30
           command: |
-            find . -name "*.js" | grep -v node_modules | grep -v test | xargs sed -i "s/@prisma\/client/db/g"
-            find . -name "*.prisma" | grep -v node_modules | xargs sed -i '/generator client {/a output = "client"'
-            find . -name "package.json" | grep -v node_modules | xargs sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
+            export FORCE_CUSTOM_OUTPUT=1
             bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: notify-slack

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1383,7 +1383,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (default output)
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1392,7 +1391,6 @@ jobs:
           command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (custom output)
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -198,7 +198,7 @@ jobs:
 
   process-managers:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'process-managers')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'process-managers')
 
     strategy:
       fail-fast: false
@@ -248,7 +248,7 @@ jobs:
 
   docker:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker')
 
     strategy:
       fail-fast: false
@@ -344,7 +344,7 @@ jobs:
   # Meaning a successfull run actually shows a non zero exit code in the logs
   docker-unsupported:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker-unsupported')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker-unsupported')
 
     strategy:
       fail-fast: false
@@ -398,7 +398,7 @@ jobs:
 
   core-features:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'core-features')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'core-features')
 
     strategy:
       fail-fast: false
@@ -478,7 +478,7 @@ jobs:
 
   migrate:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'migrate')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'migrate')
 
     strategy:
       fail-fast: false
@@ -528,7 +528,7 @@ jobs:
 
   engines:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'engines')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'engines')
 
     strategy:
       fail-fast: false
@@ -575,7 +575,7 @@ jobs:
 
   os:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'os')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'os')
 
     strategy:
       fail-fast: false
@@ -626,7 +626,7 @@ jobs:
   # so as a workaround we test this version with npm
   node16dot13:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node16dot13')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node16dot13')
 
     strategy:
       fail-fast: false
@@ -677,7 +677,7 @@ jobs:
 
   node:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node')
 
     strategy:
       fail-fast: false
@@ -736,7 +736,7 @@ jobs:
 
   binaries:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'binaries')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'binaries')
 
     strategy:
       fail-fast: false
@@ -789,7 +789,7 @@ jobs:
 
   packagers:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'packagers')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'packagers')
 
     strategy:
       fail-fast: false
@@ -865,7 +865,7 @@ jobs:
 
   frameworks:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'frameworks')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'frameworks')
 
     strategy:
       fail-fast: false
@@ -918,7 +918,7 @@ jobs:
 
   platforms:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms')
 
     timeout-minutes: 60
     strategy:
@@ -979,7 +979,7 @@ jobs:
 
   platforms-serverless:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1076,7 +1076,7 @@ jobs:
 
   platforms-serverless-vercel:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless-vercel')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless-vercel')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1404,7 +1404,7 @@ jobs:
   # it would be great if we could run them in parallel by letting them use the db provided by E2E
   accelerate:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'accelerate')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'accelerate')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1512,7 +1512,7 @@ jobs:
 
   bundlers:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'bundlers')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'bundlers')
 
     strategy:
       fail-fast: false
@@ -1566,7 +1566,7 @@ jobs:
 
   libraries:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'libraries')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'libraries')
 
     strategy:
       fail-fast: false
@@ -1619,7 +1619,7 @@ jobs:
 
   databases:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases')
 
     strategy:
       fail-fast: false
@@ -1706,7 +1706,7 @@ jobs:
 
   databases-macos:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases-macos')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases-macos')
 
     strategy:
       fail-fast: false
@@ -1752,7 +1752,7 @@ jobs:
 
   test-runners:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'test-runners')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'test-runners')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1159,7 +1159,7 @@ jobs:
 
   driver-adapters:
     needs: [detect_jobs_to_run]
-    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'driver-adapters')
+    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'driver-adapters')
 
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1382,7 +1382,7 @@ jobs:
           replaced=${string/$search/$replace}
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
-      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }}
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (default output)
         id: run-test
         uses: nick-invision/retry@v2
         with:
@@ -1390,6 +1390,19 @@ jobs:
           max_attempts: 1
           retry_wait_seconds: 30
           command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
+
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (custom output)
+        id: run-test
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 1
+          retry_wait_seconds: 30
+          command: |
+            find . -name "*.js" | grep -v node_modules | grep -v test | xargs sed -i "s/@prisma\/client/db/g"
+            find . -name "*.prisma" | grep -v node_modules | xargs sed -i '/generator client {/a output = "client"'
+            find . -name "package.json" | grep -v node_modules | xargs sed -i '/"dependencies": {/a "db": "link:./prisma/client",'
+            bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: notify-slack
         if: failure()

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1274,7 +1274,7 @@ jobs:
           max_attempts: 1
           retry_wait_seconds: 30
           command: |
-            export FORCE_CUSTOM_OUTPUT=1
+            export FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT=1
             bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: notify-slack
@@ -1393,7 +1393,7 @@ jobs:
           max_attempts: 1
           retry_wait_seconds: 30
           command: |
-            export FORCE_CUSTOM_OUTPUT=1
+            export FORCE_PRISMA_CLIENT_CUSTOM_OUTPUT=1
             bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: notify-slack

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1259,13 +1259,23 @@ jobs:
           replaced=${string/$search/$replace}
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
-      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }}
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} (default output)
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
           max_attempts: 1
           retry_wait_seconds: 30
           command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
+
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} (custom output)
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 60
+          max_attempts: 1
+          retry_wait_seconds: 30
+          command: |
+            export FORCE_CUSTOM_OUTPUT=1
+            bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
       - name: notify-slack
         if: failure()
@@ -1368,7 +1378,7 @@ jobs:
           replaced=${string/$search/$replace}
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
-      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (default output)
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} (default output)
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1376,7 +1386,7 @@ jobs:
           retry_wait_seconds: 30
           command: bash .github/scripts/test-project.sh ${{ github.job }} ${{ matrix.combo }}
 
-      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} - (custom output)
+      - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }} (custom output)
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -198,7 +198,7 @@ jobs:
 
   process-managers:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'process-managers')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'process-managers')
 
     strategy:
       fail-fast: false
@@ -248,7 +248,7 @@ jobs:
 
   docker:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker')
 
     strategy:
       fail-fast: false
@@ -344,7 +344,7 @@ jobs:
   # Meaning a successfull run actually shows a non zero exit code in the logs
   docker-unsupported:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker-unsupported')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'docker-unsupported')
 
     strategy:
       fail-fast: false
@@ -398,7 +398,7 @@ jobs:
 
   core-features:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'core-features')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'core-features')
 
     strategy:
       fail-fast: false
@@ -478,7 +478,7 @@ jobs:
 
   migrate:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'migrate')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'migrate')
 
     strategy:
       fail-fast: false
@@ -528,7 +528,7 @@ jobs:
 
   engines:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'engines')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'engines')
 
     strategy:
       fail-fast: false
@@ -575,7 +575,7 @@ jobs:
 
   os:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'os')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'os')
 
     strategy:
       fail-fast: false
@@ -626,7 +626,7 @@ jobs:
   # so as a workaround we test this version with npm
   node16dot13:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node16dot13')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node16dot13')
 
     strategy:
       fail-fast: false
@@ -677,7 +677,7 @@ jobs:
 
   node:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'node')
 
     strategy:
       fail-fast: false
@@ -736,7 +736,7 @@ jobs:
 
   binaries:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'binaries')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'binaries')
 
     strategy:
       fail-fast: false
@@ -789,7 +789,7 @@ jobs:
 
   packagers:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'packagers')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'packagers')
 
     strategy:
       fail-fast: false
@@ -865,7 +865,7 @@ jobs:
 
   frameworks:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'frameworks')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'frameworks')
 
     strategy:
       fail-fast: false
@@ -918,7 +918,7 @@ jobs:
 
   platforms:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms')
 
     timeout-minutes: 60
     strategy:
@@ -979,7 +979,7 @@ jobs:
 
   platforms-serverless:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1076,7 +1076,7 @@ jobs:
 
   platforms-serverless-vercel:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless-vercel')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'platforms-serverless-vercel')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1159,7 +1159,7 @@ jobs:
 
   driver-adapters:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'driver-adapters')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'driver-adapters')
 
     timeout-minutes: 30
     strategy:
@@ -1396,7 +1396,7 @@ jobs:
   # it would be great if we could run them in parallel by letting them use the db provided by E2E
   accelerate:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'accelerate')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'accelerate')
 
     timeout-minutes: 60 # can take longer if platforms are down, so better protect
     strategy:
@@ -1504,7 +1504,7 @@ jobs:
 
   bundlers:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'bundlers')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'bundlers')
 
     strategy:
       fail-fast: false
@@ -1558,7 +1558,7 @@ jobs:
 
   libraries:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'libraries')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'libraries')
 
     strategy:
       fail-fast: false
@@ -1611,7 +1611,7 @@ jobs:
 
   databases:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases')
 
     strategy:
       fail-fast: false
@@ -1698,7 +1698,7 @@ jobs:
 
   databases-macos:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases-macos')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'databases-macos')
 
     strategy:
       fail-fast: false
@@ -1744,7 +1744,7 @@ jobs:
 
   test-runners:
     needs: [detect_jobs_to_run]
-    if: contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'test-runners')
+    if: false && contains(fromJSON(needs.detect_jobs_to_run.outputs.jobs), 'test-runners')
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -236,7 +236,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test feature - ${{ matrix.feature }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -331,7 +330,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test feature - ${{ matrix.feature }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 20
@@ -468,7 +466,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test feature - ${{ matrix.feature }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -519,7 +516,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test feature - ${{ matrix.feature }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -616,7 +612,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test on ${{ matrix.os }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -670,7 +665,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test on node ${{ matrix.node }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -730,7 +724,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test on node ${{ matrix.node }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -784,7 +777,6 @@ jobs:
       #     echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.binary }} binary on ${{ matrix.os }} using ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -861,7 +853,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: packager ${{ matrix.packager }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -915,7 +906,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: framework ${{ matrix.framework }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -977,7 +967,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.platform }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1075,7 +1064,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.platform }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1157,7 +1145,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.platform }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1273,7 +1260,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.combo }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 60
@@ -1560,7 +1546,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.bundler }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -1614,7 +1599,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.library }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -1702,7 +1686,6 @@ jobs:
         run: pnpm install
 
       - name: test ${{ matrix.database }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -1749,7 +1732,6 @@ jobs:
         run: pnpm install
 
       - name: test ${{ matrix.database }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
@@ -1801,7 +1783,6 @@ jobs:
           echo "DATABASE_URL=$replaced" >> $GITHUB_ENV
 
       - name: test ${{ matrix.test-runner }} - ${{ matrix.clientEngine }}
-        id: run-test
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10

--- a/driver-adapters-wasm/neon-cf-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-cf-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-cfpages-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-cfpages-basic/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
+  
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-http-cf-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-http-cf-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-http-vercel-nextjs-edgemw/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-http-vercel-nextjs-edgemw/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-node-nextjs-edgemw/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-node-nextjs-edgemw/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-vercel-nextjs-app-edgefn/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-vercel-nextjs-app-edgefn/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-vercel-nextjs-edgemw/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-vercel-nextjs-edgemw/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/neon-vercel-nextjs-pages-edgefn/prisma/schema.prisma
+++ b/driver-adapters-wasm/neon-vercel-nextjs-pages-edgefn/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/pg-cf-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/pg-cf-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/pg-cfpages-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/pg-cfpages-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/pg-node-basic-esm/prisma/schema.prisma
+++ b/driver-adapters-wasm/pg-node-basic-esm/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/pg-node-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/pg-node-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/planetscale-cf-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/planetscale-cf-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/planetscale-cfpages-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/planetscale-cfpages-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/planetscale-vercel-nextjs-edgemw/prisma/schema.prisma
+++ b/driver-adapters-wasm/planetscale-vercel-nextjs-edgemw/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/turso-cf-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/turso-cf-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/turso-cfpages-basic/prisma/schema.prisma
+++ b/driver-adapters-wasm/turso-cfpages-basic/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {

--- a/driver-adapters-wasm/turso-vercel-nextjs-edgemw/prisma/schema.prisma
+++ b/driver-adapters-wasm/turso-vercel-nextjs-edgemw/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  engineType      = "wasm"
 }
 
 datasource db {


### PR DESCRIPTION
Uses the shell wand :magic_wand:  to test all our driver adapter tests with a custom output and configured as documented. This means we now have two steps instead of one, to test with regular and custom outputs within the same project.

Failing tests are [unrelated](https://prisma-company.slack.com/archives/C04TW4A2H8C/p1706044899165809).

closes https://github.com/prisma/team-orm/issues/862