### PR TITLE
test(vercel-node-builder): update file snapshot

### DIFF
--- a/platforms-serverless-vercel/vercel-node-builder/test.sh
+++ b/platforms-serverless-vercel/vercel-node-builder/test.sh
@@ -4,9 +4,9 @@ set -eux
 DEPLOYED_URL=$( tail -n 1 deployment-url.txt )
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.js","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]'
+  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.js","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]'
+  files=',"default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url $DEPLOYED_URL --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string ${files}

--- a/platforms-serverless-vercel/vercel-node-builder/test.sh
+++ b/platforms-serverless-vercel/vercel-node-builder/test.sh
@@ -6,7 +6,7 @@ DEPLOYED_URL=$( tail -n 1 deployment-url.txt )
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
   files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url $DEPLOYED_URL --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string ${files}


### PR DESCRIPTION
Related to https://github.com/prisma/prisma/pull/22880

We think `nft` from Vercel cannot optimize the packaged files anymore.

So with this PR we expect the previous behavior (like in < `5.9.0`) but with extra files.

See https://github.com/prisma/ecosystem-tests/pull/4471 for more details. 
