### PR TITLE
ci(check-update): pin pnpm to v8

### DIFF
--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -7,6 +7,9 @@ NEW_VERSION=$(npm show prisma@$1 version)
 echo "$NEW_VERSION" > .github/prisma-version.txt
 
 corepack enable # auto install correct yarn versions automatically
+# Pin to v8 as latest (v9) needs Node.js v18.12 minimum
+# see https://r.pnpm.io/comp
+corepack install --global pnpm@8
 
 # first update all the versions in all the projects for perf gains
 pnpm -rc --parallel exec "$(pwd)/scripts/update-version.sh $NEW_VERSION"

--- a/scripts/update-locks.sh
+++ b/scripts/update-locks.sh
@@ -1,6 +1,9 @@
 #! /bin/sh
 
 corepack enable
+# Pin to v8 as latest (v9) needs Node.js v18.12 minimum
+# see https://r.pnpm.io/comp
+corepack install --global pnpm@8
 
 # Setting NODE_OPTIONS="" disables yarn-injected shenanigans so we can use package from the root
 PROJECT_PACKAGE_MANAGER=$(NODE_OPTIONS="" node -e "require('@antfu/ni').detect({ autoinstall: false }).then(console.log)")


### PR DESCRIPTION
Because we still run on Node.js v16, we should later upgrade everything to v18 and unpin pnpm.

Currently fails with
https://github.com/prisma/ecosystem-tests/actions/runs/8797597444/job/24142829992
```
+ npm show prisma@5.13.0-dev.37 version
+ NEW_VERSION=5.13.0-dev.37
+ echo 5.13.0-dev.37
+ corepack enable
+ pwd
+ pnpm -rc --parallel exec /home/runner/work/ecosystem-tests/ecosystem-tests/scripts/update-version.sh 5.13.0-dev.37
ERROR: This version of pnpm requires at least Node.js v18.12
The current version of Node.js is v16.20.2
Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```