### PR TITLE
ci(engine-types): pin runner to macos-13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -534,7 +534,10 @@ jobs:
       fail-fast: false
       matrix:
         feature: [engine-types, engine-native-deps]
-        os: [ubuntu-20.04, windows-latest, macos-latest]
+        # macos-13 is pinned because engine-types test
+        # need to be updated before running on macos-14 because the engines
+        # names are different because it's arm64 / m1
+        os: [ubuntu-20.04, windows-latest, macos-13]
         exclude:
           - feature: engine-native-deps
             os: windows-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -536,7 +536,7 @@ jobs:
         feature: [engine-types, engine-native-deps]
         # macos-13 is pinned because engine-types test
         # need to be updated before running on macos-14 because the engines
-        # names are different because it's arm64 / m1
+        # names are different because macos-latest is now arm64 / M1 CPU
         os: [ubuntu-20.04, windows-latest, macos-13]
         exclude:
           - feature: engine-native-deps

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -13,7 +13,7 @@ echo "$NEW_VERSION" > .github/prisma-version.txt
 corepack prepare pnpm@8.15.7 --activate
 corepack enable # auto install correct yarn versions automatically
 
-pnpm -v
+# pnpm -v
 
 # first update all the versions in all the projects for perf gains
 pnpm -rc --parallel exec "$(pwd)/scripts/update-version.sh $NEW_VERSION"

--- a/scripts/update-locks.sh
+++ b/scripts/update-locks.sh
@@ -7,7 +7,7 @@
 corepack prepare pnpm@8.15.7 --activate
 corepack enable
 
-pnpm -v
+# pnpm -v
 
 # Setting NODE_OPTIONS="" disables yarn-injected shenanigans so we can use package from the root
 PROJECT_PACKAGE_MANAGER=$(NODE_OPTIONS="" node -e "require('@antfu/ni').detect({ autoinstall: false }).then(console.log)")


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories


macos-13 needs to be pinned because engine-types test needs to be updated before running on macos-14 because the engines names are different because macos-latest is now arm64 / M1 CPU