### PR TITLE
ci(engine-native-deps): align macos version in exclude

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -542,7 +542,8 @@ jobs:
           - feature: engine-native-deps
             os: windows-latest
           - feature: engine-native-deps
-            os: macos-latest
+            # Note that this must match the value in "os" above
+            os: macos-13
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
I changed the os value and forgot to update this value.

Follows https://github.com/prisma/ecosystem-tests/pull/4860