### PR TITLE
test(pg-cf-hyperdrive): improve delete hyperdrive script

### DIFF
--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -29,7 +29,7 @@ npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
 EXISTING_HYPERDRIVE=$(cat $TMP_FILE | grep $HYPERDRIVE_NAME)
 if [ -z "$EXISTING_HYPERDRIVE" ]; then
-  cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
+  $EXISTING_HYPERDRIVE | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
 fi
 
 # Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -27,8 +27,9 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
-if cat $TMP_FILE | grep $HYPERDRIVE_NAME; then
-    cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
+EXISTING_HYPERDRIVE=$(cat $TMP_FILE | grep $HYPERDRIVE_NAME)
+if [ -z "$EXISTING_HYPERDRIVE" ]; then
+  cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
 fi
 
 # Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -27,7 +27,7 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
-export EXISTING_HYPERDRIVE_OUTPUT=$(cat $TMP_FILE | grep -q $HYPERDRIVE_NAME)
+EXISTING_HYPERDRIVE_OUTPUT=$(grep $HYPERDRIVE_NAME $TMP_FILE)
 if [ -n "$EXISTING_HYPERDRIVE_OUTPUT" ]; then
   echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
   echo "$EXISTING_HYPERDRIVE_OUTPUT" | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 
+set -eux
+
 export TMP_FILE=hyperdrive.tmp
 export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests driver-adapters-wasm pg-cf-hyperdrive build'
 export PRISMA_CLIENT_ENGINE_TYPE='wasm' # because setup otherwise makes it library/binary
 export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 
 # Delete a previous hyperdrive with the same name if exists, unfortunately wrangler output cannot
-# be parsed as JSON, so we need to filter out the id from the output table. We do it in two steps 
-# to count with debugging output 
+# be parsed as JSON, so we need to filter out the id from the output table. We do it in two steps
+# to count with debugging output
 #
 # Example output of `wrangler hyperdrive list`:
 #
@@ -24,9 +26,9 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # └──────────────────────────────────┴─────────────────────────────┴──────────────────────┴───────────────────────────────────────────────────────────────────────┴──────┴────────────────┴────────────────────┘
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
-cat $TMP_FILE | grep $HYPERDRIVE_NAME |cut -f2 -d' ' |xargs npx wrangler hyperdrive delete
+cat $TMP_FILE | grep $HYPERDRIVE_NAME | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
 
-# Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out 
+# Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out
 # the first two lines to parse the JSON.
 #
 # Example output of `wrangler hyperdrive create hyperdrive-orm-tests-foo --connection-string=$DATABASE_URL`:

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -27,9 +27,12 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
-EXISTING_HYPERDRIVE=$(cat $TMP_FILE | grep $HYPERDRIVE_NAME)
-if [ -z "$EXISTING_HYPERDRIVE" ]; then
-  $EXISTING_HYPERDRIVE | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
+EXISTING_HYPERDRIVE_OUTPUT=$(cat $TMP_FILE | grep -q $HYPERDRIVE_NAME)
+if [ -n "$EXISTING_HYPERDRIVE_OUTPUT" ]; then
+  echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
+  $EXISTING_HYPERDRIVE_OUTPUT | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
+else
+  echo "✅ No existing hyperdrive with name $HYPERDRIVE_NAME - We can continue..."
 fi
 
 # Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out
@@ -62,7 +65,6 @@ if [ -z "$DATABASE_URL" ]; then
 fi
 
 npx wrangler hyperdrive create $HYPERDRIVE_NAME --connection-string=\"$DATABASE_URL\" | tee $TMP_FILE
-cat $TMP_FILE
 export HYPERDRIVE_ID=$(cat $TMP_FILE | sed 1,2d | jq .id)
 
 cat <<EOF > wrangler.toml

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -30,7 +30,7 @@ npx wrangler hyperdrive list | tee $TMP_FILE
 EXISTING_HYPERDRIVE_OUTPUT=$(cat $TMP_FILE | grep -q $HYPERDRIVE_NAME)
 if [ -n "$EXISTING_HYPERDRIVE_OUTPUT" ]; then
   echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
-  $EXISTING_HYPERDRIVE_OUTPUT | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
+  echo "$EXISTING_HYPERDRIVE_OUTPUT" | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
 else
   echo "✅ No existing hyperdrive with name $HYPERDRIVE_NAME - We can continue..."
 fi

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -27,7 +27,7 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
-EXISTING_HYPERDRIVE_OUTPUT=$(cat $TMP_FILE | grep -q $HYPERDRIVE_NAME)
+export EXISTING_HYPERDRIVE_OUTPUT=$(cat $TMP_FILE | grep -q $HYPERDRIVE_NAME)
 if [ -n "$EXISTING_HYPERDRIVE_OUTPUT" ]; then
   echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
   echo "$EXISTING_HYPERDRIVE_OUTPUT" | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete

--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -27,12 +27,11 @@ export HYPERDRIVE_NAME='hyperdrive-pg-cf-hyperdrive'
 # ```
 npx wrangler hyperdrive list | tee $TMP_FILE
 # Only try to delete if the hyperdrive exists
-EXISTING_HYPERDRIVE_OUTPUT=$(grep $HYPERDRIVE_NAME $TMP_FILE)
-if [ -n "$EXISTING_HYPERDRIVE_OUTPUT" ]; then
-  echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
-  echo "$EXISTING_HYPERDRIVE_OUTPUT" | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
-else
+if [ $(grep -c $HYPERDRIVE_NAME $TMP_FILE) = 0 ]; then
   echo "✅ No existing hyperdrive with name $HYPERDRIVE_NAME - We can continue..."
+else
+  echo "Existing hyperdrive with name $HYPERDRIVE_NAME - We will delete it..."
+  grep $HYPERDRIVE_NAME $TMP_FILE | cut -f2 -d' ' | xargs npx wrangler hyperdrive delete
 fi
 
 # Create the hyperdrive to connecto the Database. Unfortunately wrangler output mixes JSON and text, so we need to filter out


### PR DESCRIPTION
It's failing on the default branch `dev`, it looks like the script cannot recover if the hyperdrive config does not exist because it will try to delete it and fail.

This adds a check that if it does not exist, it continues.