### PR TITLE
test(D1/turso): uncomment `.createMany()`

### DIFF
--- a/driver-adapters-wasm/d1-cf-basic/index.test.js
+++ b/driver-adapters-wasm/d1-cf-basic/index.test.js
@@ -18,8 +18,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // Not available for SQLite
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters-wasm/d1-cf-basic/src/index.js
+++ b/driver-adapters-wasm/d1-cf-basic/src/index.js
@@ -23,21 +23,20 @@ export default {
             name: true,
           },
         }),
-        // Not available for SQLite
-        // createMany: await prisma.user.createMany({
-        //   data: [
-        //     {
-        //       email: `test-2@prisma.io`,
-        //       age: 29,
-        //       name: 'Test 2',
-        //     },
-        //     {
-        //       email: `test-3@prisma.io`,
-        //       age: 29,
-        //       name: 'Test 3',
-        //     },
-        //   ],
-        // }),
+        createMany: await prisma.user.createMany({
+          data: [
+            {
+              email: `test-2@prisma.io`,
+              age: 29,
+              name: 'Test 2',
+            },
+            {
+              email: `test-3@prisma.io`,
+              age: 29,
+              name: 'Test 3',
+            },
+          ],
+        }),
         create2: await prisma.user.create({
           data: {
             email: `test-2@prisma.io`,

--- a/driver-adapters-wasm/d1-cf-basic/src/index.js
+++ b/driver-adapters-wasm/d1-cf-basic/src/index.js
@@ -37,30 +37,6 @@ export default {
             },
           ],
         }),
-        create2: await prisma.user.create({
-          data: {
-            email: `test-2@prisma.io`,
-            age: 29,
-            name: 'Test 2',
-          },
-          select: {
-            email: true,
-            age: true,
-            name: true,
-          },
-        }),
-        create3: await prisma.user.create({
-          data: {
-            email: `test-3@prisma.io`,
-            age: 29,
-            name: 'Test 3',
-          },
-          select: {
-            email: true,
-            age: true,
-            name: true,
-          },
-        }),
         findMany: await prisma.user.findMany({
           select: {
             email: true,

--- a/driver-adapters-wasm/d1-cfpages-basic/functions/function.js
+++ b/driver-adapters-wasm/d1-cfpages-basic/functions/function.js
@@ -22,21 +22,20 @@ export async function onRequest(context) {
           name: true,
         },
       }),
-      // Not available for SQLite
-      // createMany: await prisma.user.createMany({
-      //   data: [
-      //     {
-      //       email: `test-2@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 2',
-      //     },
-      //     {
-      //       email: `test-3@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 3',
-      //     },
-      //   ],
-      // }),
+      createMany: await prisma.user.createMany({
+        data: [
+          {
+            email: `test-2@prisma.io`,
+            age: 29,
+            name: 'Test 2',
+          },
+          {
+            email: `test-3@prisma.io`,
+            age: 29,
+            name: 'Test 3',
+          },
+        ],
+      }),
       create2: await prisma.user.create({
         data: {
           email: `test-2@prisma.io`,

--- a/driver-adapters-wasm/d1-cfpages-basic/functions/function.js
+++ b/driver-adapters-wasm/d1-cfpages-basic/functions/function.js
@@ -36,30 +36,6 @@ export async function onRequest(context) {
           },
         ],
       }),
-      create2: await prisma.user.create({
-        data: {
-          email: `test-2@prisma.io`,
-          age: 29,
-          name: 'Test 2',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
-      create3: await prisma.user.create({
-        data: {
-          email: `test-3@prisma.io`,
-          age: 29,
-          name: 'Test 3',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
       findMany: await prisma.user.findMany({
         select: {
           email: true,

--- a/driver-adapters-wasm/d1-cfpages-basic/index.test.js
+++ b/driver-adapters-wasm/d1-cfpages-basic/index.test.js
@@ -18,8 +18,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // Not available for SQLite
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters-wasm/turso-cf-basic/index.test.js
+++ b/driver-adapters-wasm/turso-cf-basic/index.test.js
@@ -19,7 +19,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters-wasm/turso-cf-basic/src/index.js
+++ b/driver-adapters-wasm/turso-cf-basic/src/index.js
@@ -42,30 +42,6 @@ export default {
             },
           ],
         }),
-        create2: await prisma.user.create({
-          data: {
-            email: `test-2@prisma.io`,
-            age: 29,
-            name: 'Test 2',
-          },
-          select: {
-            email: true,
-            age: true,
-            name: true,
-          },
-        }),
-        create3: await prisma.user.create({
-          data: {
-            email: `test-3@prisma.io`,
-            age: 29,
-            name: 'Test 3',
-          },
-          select: {
-            email: true,
-            age: true,
-            name: true,
-          },
-        }),
         findMany: await prisma.user.findMany({
           select: {
             email: true,

--- a/driver-adapters-wasm/turso-cf-basic/src/index.js
+++ b/driver-adapters-wasm/turso-cf-basic/src/index.js
@@ -7,7 +7,7 @@ export default {
   async fetch(request, env, ctx) {
     const client = createClient({
       url: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_DATABASE_URL,
-      authToken: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_TOKEN
+      authToken: env.DRIVER_ADAPTERS_TURSO_CF_BASIC_TOKEN,
     })
     const adapter = new PrismaLibSQL(client)
     const prisma = new PrismaClient({ adapter })
@@ -28,20 +28,20 @@ export default {
             name: true,
           },
         }),
-        // createMany: await prisma.user.createMany({
-        //   data: [
-        //     {
-        //       email: `test-2@prisma.io`,
-        //       age: 29,
-        //       name: 'Test 2',
-        //     },
-        //     {
-        //       email: `test-3@prisma.io`,
-        //       age: 29,
-        //       name: 'Test 3',
-        //     },
-        //   ],
-        // }),
+        createMany: await prisma.user.createMany({
+          data: [
+            {
+              email: `test-2@prisma.io`,
+              age: 29,
+              name: 'Test 2',
+            },
+            {
+              email: `test-3@prisma.io`,
+              age: 29,
+              name: 'Test 3',
+            },
+          ],
+        }),
         create2: await prisma.user.create({
           data: {
             email: `test-2@prisma.io`,
@@ -179,17 +179,17 @@ export default {
         //   },
         // }),
       }
-  
+
       // sort results by email to make the order deterministic
       result.findMany = result.findMany.sort((a, b) => (a.email > b.email ? 1 : -1))
-  
+
       return result
     }
-  
+
     const regResult = await getResult(prisma).catch((error) => ({ error: error.message }))
     const itxResult = await prisma.$transaction(getResult).catch((error) => ({ error: error.message }))
     const result = JSON.stringify({ itxResult, regResult })
 
-    return new Response(result);
-  }
+    return new Response(result)
+  },
 }

--- a/driver-adapters-wasm/turso-cfpages-basic/functions/function.js
+++ b/driver-adapters-wasm/turso-cfpages-basic/functions/function.js
@@ -41,30 +41,6 @@ export async function onRequest(context) {
           },
         ],
       }),
-      create2: await prisma.user.create({
-        data: {
-          email: `test-2@prisma.io`,
-          age: 29,
-          name: 'Test 2',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
-      create3: await prisma.user.create({
-        data: {
-          email: `test-3@prisma.io`,
-          age: 29,
-          name: 'Test 3',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
       findMany: await prisma.user.findMany({
         select: {
           email: true,

--- a/driver-adapters-wasm/turso-cfpages-basic/functions/function.js
+++ b/driver-adapters-wasm/turso-cfpages-basic/functions/function.js
@@ -6,7 +6,7 @@ import { PrismaLibSQL } from '@prisma/adapter-libsql'
 export async function onRequest(context) {
   const client = createClient({
     url: context.env.DRIVER_ADAPTERS_TURSO_CFPAGES_BASIC_DATABASE_URL,
-    authToken: context.env.DRIVER_ADAPTERS_TURSO_CFPAGES_BASIC_TOKEN
+    authToken: context.env.DRIVER_ADAPTERS_TURSO_CFPAGES_BASIC_TOKEN,
   })
   const adapter = new PrismaLibSQL(client)
   const prisma = new PrismaClient({ adapter })
@@ -27,20 +27,20 @@ export async function onRequest(context) {
           name: true,
         },
       }),
-      // createMany: await prisma.user.createMany({
-      //   data: [
-      //     {
-      //       email: `test-2@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 2',
-      //     },
-      //     {
-      //       email: `test-3@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 3',
-      //     },
-      //   ],
-      // }),
+      createMany: await prisma.user.createMany({
+        data: [
+          {
+            email: `test-2@prisma.io`,
+            age: 29,
+            name: 'Test 2',
+          },
+          {
+            email: `test-3@prisma.io`,
+            age: 29,
+            name: 'Test 3',
+          },
+        ],
+      }),
       create2: await prisma.user.create({
         data: {
           email: `test-2@prisma.io`,
@@ -189,5 +189,5 @@ export async function onRequest(context) {
   const itxResult = await prisma.$transaction(getResult).catch((error) => ({ error: error.message }))
   const result = JSON.stringify({ itxResult, regResult })
 
-  return new Response(result);
+  return new Response(result)
 }

--- a/driver-adapters-wasm/turso-cfpages-basic/index.test.js
+++ b/driver-adapters-wasm/turso-cfpages-basic/index.test.js
@@ -19,7 +19,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters-wasm/turso-vercel-nextjs-edgemw/index.test.js
+++ b/driver-adapters-wasm/turso-vercel-nextjs-edgemw/index.test.js
@@ -16,7 +16,7 @@ function getDeploymentURL() {
 jest.setTimeout(30_000)
 
 test('prisma version and output', async () => {
-  const response = await fetch(await getDeploymentURL() + '/')
+  const response = await fetch((await getDeploymentURL()) + '/')
   const { regResult, itxResult } = await response.json()
 
   expect(regResult).toEqual(itxResult)
@@ -29,7 +29,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters-wasm/turso-vercel-nextjs-edgemw/middleware.js
+++ b/driver-adapters-wasm/turso-vercel-nextjs-edgemw/middleware.js
@@ -28,20 +28,20 @@ async function getResponse() {
           name: true,
         },
       }),
-      // createMany: await prisma.user.createMany({
-      //   data: [
-      //     {
-      //       email: `test-2@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 2',
-      //     },
-      //     {
-      //       email: `test-3@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 3',
-      //     },
-      //   ],
-      // }),
+      createMany: await prisma.user.createMany({
+        data: [
+          {
+            email: `test-2@prisma.io`,
+            age: 29,
+            name: 'Test 2',
+          },
+          {
+            email: `test-3@prisma.io`,
+            age: 29,
+            name: 'Test 3',
+          },
+        ],
+      }),
       create2: await prisma.user.create({
         data: {
           email: `test-2@prisma.io`,
@@ -186,7 +186,7 @@ async function getResponse() {
 
   const regResult = await getResult(prisma).catch((error) => ({ error: error.message }))
   const itxResult = await prisma.$transaction(getResult).catch((error) => ({ error: error.message }))
-  
+
   return { itxResult, regResult }
 }
 

--- a/driver-adapters-wasm/turso-vercel-nextjs-edgemw/middleware.js
+++ b/driver-adapters-wasm/turso-vercel-nextjs-edgemw/middleware.js
@@ -42,30 +42,6 @@ async function getResponse() {
           },
         ],
       }),
-      create2: await prisma.user.create({
-        data: {
-          email: `test-2@prisma.io`,
-          age: 29,
-          name: 'Test 2',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
-      create3: await prisma.user.create({
-        data: {
-          email: `test-3@prisma.io`,
-          age: 29,
-          name: 'Test 3',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
       findMany: await prisma.user.findMany({
         select: {
           email: true,

--- a/driver-adapters/turso-lambda-basic/index.js
+++ b/driver-adapters/turso-lambda-basic/index.js
@@ -40,30 +40,6 @@ exports.handler = async () => {
         },
       ],
     }),
-    create2: await prisma.user.create({
-      data: {
-        email: `test-2@prisma.io`,
-        age: 29,
-        name: 'Test 2',
-      },
-      select: {
-        email: true,
-        age: true,
-        name: true,
-      },
-    }),
-    create3: await prisma.user.create({
-      data: {
-        email: `test-3@prisma.io`,
-        age: 29,
-        name: 'Test 3',
-      },
-      select: {
-        email: true,
-        age: true,
-        name: true,
-      },
-    }),
     findMany: await prisma.user.findMany({
       select: {
         email: true,

--- a/driver-adapters/turso-lambda-basic/index.js
+++ b/driver-adapters/turso-lambda-basic/index.js
@@ -26,20 +26,20 @@ exports.handler = async () => {
         name: true,
       },
     }),
-    // createMany: await prisma.user.createMany({
-    //   data: [
-    //     {
-    //       email: `test-2@prisma.io`,
-    //       age: 29,
-    //       name: 'Test 2',
-    //     },
-    //     {
-    //       email: `test-3@prisma.io`,
-    //       age: 29,
-    //       name: 'Test 3',
-    //     },
-    //   ],
-    // }),
+    createMany: await prisma.user.createMany({
+      data: [
+        {
+          email: `test-2@prisma.io`,
+          age: 29,
+          name: 'Test 2',
+        },
+        {
+          email: `test-3@prisma.io`,
+          age: 29,
+          name: 'Test 3',
+        },
+      ],
+    }),
     create2: await prisma.user.create({
       data: {
         email: `test-2@prisma.io`,

--- a/driver-adapters/turso-lambda-basic/index.test.js
+++ b/driver-adapters/turso-lambda-basic/index.test.js
@@ -36,7 +36,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters/turso-node-basic/index.js
+++ b/driver-adapters/turso-node-basic/index.js
@@ -40,30 +40,6 @@ exports.handler = async () => {
         },
       ],
     }),
-    create2: await prisma.user.create({
-      data: {
-        email: `test-2@prisma.io`,
-        age: 29,
-        name: 'Test 2',
-      },
-      select: {
-        email: true,
-        age: true,
-        name: true,
-      },
-    }),
-    create3: await prisma.user.create({
-      data: {
-        email: `test-3@prisma.io`,
-        age: 29,
-        name: 'Test 3',
-      },
-      select: {
-        email: true,
-        age: true,
-        name: true,
-      },
-    }),
     findMany: await prisma.user.findMany({
       select: {
         email: true,

--- a/driver-adapters/turso-node-basic/index.js
+++ b/driver-adapters/turso-node-basic/index.js
@@ -26,20 +26,20 @@ exports.handler = async () => {
         name: true,
       },
     }),
-    // createMany: await prisma.user.createMany({
-    //   data: [
-    //     {
-    //       email: `test-2@prisma.io`,
-    //       age: 29,
-    //       name: 'Test 2',
-    //     },
-    //     {
-    //       email: `test-3@prisma.io`,
-    //       age: 29,
-    //       name: 'Test 3',
-    //     },
-    //   ],
-    // }),
+    createMany: await prisma.user.createMany({
+      data: [
+        {
+          email: `test-2@prisma.io`,
+          age: 29,
+          name: 'Test 2',
+        },
+        {
+          email: `test-3@prisma.io`,
+          age: 29,
+          name: 'Test 3',
+        },
+      ],
+    }),
     create2: await prisma.user.create({
       data: {
         email: `test-2@prisma.io`,

--- a/driver-adapters/turso-node-basic/index.test.js
+++ b/driver-adapters/turso-node-basic/index.test.js
@@ -18,7 +18,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters/turso-vercel-nextjs/index.test.js
+++ b/driver-adapters/turso-vercel-nextjs/index.test.js
@@ -31,7 +31,7 @@ test('prisma version and output', async () => {
   "name": "Test 1",
 }
 `)
-  // expect(regResult.createMany.count).toBe(2)
+  expect(regResult.createMany.count).toBe(2)
   expect(regResult.findMany).toMatchInlineSnapshot(`
 [
   {

--- a/driver-adapters/turso-vercel-nextjs/pages/api/index.js
+++ b/driver-adapters/turso-vercel-nextjs/pages/api/index.js
@@ -30,20 +30,20 @@ export default async (req, res) => {
           name: true,
         },
       }),
-      // createMany: await prisma.user.createMany({
-      //   data: [
-      //     {
-      //       email: `test-2@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 2',
-      //     },
-      //     {
-      //       email: `test-3@prisma.io`,
-      //       age: 29,
-      //       name: 'Test 3',
-      //     },
-      //   ],
-      // }),
+      createMany: await prisma.user.createMany({
+        data: [
+          {
+            email: `test-2@prisma.io`,
+            age: 29,
+            name: 'Test 2',
+          },
+          {
+            email: `test-3@prisma.io`,
+            age: 29,
+            name: 'Test 3',
+          },
+        ],
+      }),
       create2: await prisma.user.create({
         data: {
           email: `test-2@prisma.io`,

--- a/driver-adapters/turso-vercel-nextjs/pages/api/index.js
+++ b/driver-adapters/turso-vercel-nextjs/pages/api/index.js
@@ -44,30 +44,6 @@ export default async (req, res) => {
           },
         ],
       }),
-      create2: await prisma.user.create({
-        data: {
-          email: `test-2@prisma.io`,
-          age: 29,
-          name: 'Test 2',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
-      create3: await prisma.user.create({
-        data: {
-          email: `test-3@prisma.io`,
-          age: 29,
-          name: 'Test 3',
-        },
-        select: {
-          email: true,
-          age: true,
-          name: true,
-        },
-      }),
       findMany: await prisma.user.findMany({
         select: {
           email: true,


### PR DESCRIPTION
Since it's now supported.

`pg-cf-hyperdrive` failure is unrelated, see https://github.com/prisma/ecosystem-tests/pull/4915