### PR TITLE
ci(DA): restrict concurrency to avoid failures in tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1239,7 +1239,11 @@ jobs:
         clientEngine: ['library']
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
-    concurrency: ${{ github.job }}-${{ matrix.combo }}-${{ matrix.clientEngine }}
+    # To avoid race conditions when running tests, we need to avoid concurrency
+    # The tests should not be run concurrently for a given "combo"
+    # Example: 2 concurrent runs of "turso-node-basic" will share the same database,
+    # which causes failures in the test expectation
+    concurrency: ${{ matrix.combo }}
     env:
       NODE_ENV: development
       NODE_MODULES_CACHE: false
@@ -1368,7 +1372,11 @@ jobs:
         clientEngine: ['wasm']
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
-    concurrency: ${{ github.job }}-${{ matrix.combo }}-${{ matrix.clientEngine }}
+    # To avoid race conditions when running tests, we need to avoid concurrency
+    # The tests should not be run concurrently for a given "combo"
+    # Example: 2 concurrent runs of "turso-node-basic" will share the same database,
+    # which causes failures in the test expectation
+    concurrency: ${{ matrix.combo }}
     env:
       NODE_ENV: development
       NODE_MODULES_CACHE: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1374,7 +1374,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     # To avoid race conditions when running tests, we need to avoid concurrency
     # The tests should not be run concurrently for a given "combo"
-    # Example: 2 concurrent runs of "turso-node-basic" will share the same database,
+    # Example: 2 concurrent runs of "turso-vercel-nextjs-edgemw" will share the same database,
     # which causes failures in the test expectation
     concurrency: ${{ matrix.combo }}
     env:


### PR DESCRIPTION
We might be able to remove the restriction if we rework the tests.

To simplify: concurrency happens when 2 of the following happen: PR is open / merged or the update checked finds a new dev / latest / integration version.

Example failure:
https://github.com/prisma/ecosystem-tests/actions/runs/9287611832/job/25557871027?pr=5005#step:8:154
```
> turso-vercel-nextjs-edgemw@ test /home/runner/work/ecosystem-tests/ecosystem-tests/driver-adapters-wasm/turso-vercel-nextjs-edgemw
> jest index.test.js

FAIL ./index.test.js (10.28 s)
  ✕ prisma version and output (9954 ms)

  ● prisma version and output

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 5

      Object {
    -   "error": "Transaction API error: Transaction already closed: Could not perform operation.",
    +   "error": "
    + Invalid `prisma.user.createMany()` invocation:
    +
    +
    + SQLITE_CONSTRAINT: SQLite error: UNIQUE constraint failed: User.email",
      }
```