### PR TITLE
test(heroku): use custom output as workaround

### DIFF
--- a/platforms/heroku/.gitignore
+++ b/platforms/heroku/.gitignore
@@ -1,3 +1,4 @@
 .env
 node_modules/
 prisma/migrations
+generated/

--- a/platforms/heroku/README.md
+++ b/platforms/heroku/README.md
@@ -11,3 +11,7 @@ Alternatively, you can login using `heroku login`.
 ### Environment variables
 
 The environment variable `HEROKU_PG_URL` should point to a postgres database.
+
+### Heroku + `pnpm`
+
+There is a known issue when using `pnpm` and deploying to Heroku where the current workaround it to use a custom `output` directory for the Prisma Client. See https://github.com/prisma/prisma/issues/24199

--- a/platforms/heroku/index.js
+++ b/platforms/heroku/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 
-const { PrismaClient, Prisma } = require('./generated/client')
+const { PrismaClient, Prisma } = require('./generated/client/index.js')
 const client = new PrismaClient()
 
 const app = express()

--- a/platforms/heroku/index.js
+++ b/platforms/heroku/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 
-const { PrismaClient, Prisma } = require('./generated/client/index.js')
+const { PrismaClient, Prisma } = require('./prisma/generated/client')
 const client = new PrismaClient()
 
 const app = express()

--- a/platforms/heroku/index.js
+++ b/platforms/heroku/index.js
@@ -1,6 +1,6 @@
 const express = require('express')
 
-const { PrismaClient, Prisma } = require('@prisma/client')
+const { PrismaClient, Prisma } = require('./generated/client')
 const client = new PrismaClient()
 
 const app = express()

--- a/platforms/heroku/index.js
+++ b/platforms/heroku/index.js
@@ -9,7 +9,7 @@ const port = process.env.PORT || 3000
 app.get('/', async (req, res) => {
   const fs = require('fs')
   const path = require('path')
-  const files = fs.readdirSync(path.dirname(require.resolve('.prisma/client')))
+  const files = fs.readdirSync(path.dirname(require.resolve('./prisma/generated/client')))
 
   await client.user.deleteMany({})
 

--- a/platforms/heroku/prepare.sh
+++ b/platforms/heroku/prepare.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# See README and https://github.com/prisma/prisma/issues/24199
+# Since we use a custom output, we disabled the engine check.
+# it fails with the error below, which is expected with a custom output.
+#
+# Error: Cannot find module '.prisma/client/package.json'
+# Require stack:
+# - /home/runner/work/ecosystem-tests/ecosystem-tests/platforms/heroku/[eval]
+#     at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1028:15)
+#     at Function.resolve (node:internal/modules/cjs/helpers:125:19)
+#     at [eval]:3:26
+#     at Script.runInThisContext (node:vm:129:12)
+#     at Object.runInThisContext (node:vm:313:38)
+#     at node:internal/process/execution:79:19
+#     at [eval]-wrapper:6:22
+#     at evalScript (node:internal/process/execution:78:60)
+#     at node:internal/main/eval_string:27:3 {
+#   code: 'MODULE_NOT_FOUND',
+#   requireStack: [
+#     '/home/runner/work/ecosystem-tests/ecosystem-tests/platforms/heroku/[eval]'
+#   ]
+# }
+
+SKIP_ENGINE_CHECK=1

--- a/platforms/heroku/prisma/schema-with-binary.prisma
+++ b/platforms/heroku/prisma/schema-with-binary.prisma
@@ -1,6 +1,10 @@
 generator client {
   provider   = "prisma-client-js"
   engineType = "binary"
+  // There is a known issue when using `pnpm` and deploying to Heroku
+  // where the current workaround it to use a custom `output` directory for the Prisma Client.
+  // See https://github.com/prisma/prisma/issues/24199
+  output     = "./generated/client"
 }
 
 datasource db {

--- a/platforms/heroku/prisma/schema-with-node-api.prisma
+++ b/platforms/heroku/prisma/schema-with-node-api.prisma
@@ -6,6 +6,10 @@ datasource db {
 generator client {
   provider   = "prisma-client-js"
   engineType = "library"
+  // There is a known issue when using `pnpm` and deploying to Heroku
+  // where the current workaround it to use a custom `output` directory for the Prisma Client.
+  // See https://github.com/prisma/prisma/issues/24199
+  output     = "./generated/client"
 }
 
 model User {

--- a/platforms/heroku/test.sh
+++ b/platforms/heroku/test.sh
@@ -3,10 +3,10 @@
 set -eux
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-platforms-heroku-binary.herokuapp.com --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-platforms-heroku.herokuapp.com --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 fi
 


### PR DESCRIPTION
Related to https://github.com/prisma/prisma/issues/24199

The current `heroku` test is failing (every time it runs).

This PR brings it back by using a custom `output` outside `node_modules`.