### PR TITLE
ci(heroku/graviton): relax concurrency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -611,8 +611,7 @@ jobs:
         clientEngine: ['library', 'binary']
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
-    # concurrency: ${{ github.job }}-${{ matrix.platform }}-${{ matrix.clientEngine }}
-    concurrency: ${{ matrix.platform }}
+    concurrency: ${{ matrix.platform }}-${{ matrix.clientEngine }}
 
     env:
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
I checked and both tests should be able to handle a concurrency of "current-PR + clientEngine"