### PR TITLE
pkg: Remove useless generate

### DIFF
--- a/binaries/pkg/run.sh
+++ b/binaries/pkg/run.sh
@@ -3,7 +3,6 @@
 set -eu
 
 pnpm install
-pnpm prisma generate
 
 # This means that we resolve the location of the @prisma/engines package starting to the location of the prisma package
 ENGINES_PACKAGE=$(node -e "console.log(path.dirname(require.resolve('@prisma/engines/package.json', {paths: [path.dirname(require.resolve('prisma/package.json'))]})))")


### PR DESCRIPTION
This `generate` call is not supposed to work - there is no schema to
generate from where it is called. It was working before because generate
incorrectly thought it's called from a postinstall hook and produced
soft error instead.

Close prisma/team-orm#1183
