### PR TITLE
fix(docker): fix unbound variable PRISMA_ENGINES_MIRROR

### DIFF
--- a/.github/workflows/optional-test.yaml
+++ b/.github/workflows/optional-test.yaml
@@ -34,7 +34,7 @@ env:
   SLACK_WEBHOOK_URL_OPTIONAL_TESTS_SUCCESS: ${{ secrets.SLACK_WEBHOOK_URL_OPTIONAL_TESTS_SUCCESS }}
   SLACK_WEBHOOK_URL_OPTIONAL_TESTS_FAILING: ${{ secrets.SLACK_WEBHOOK_URL_OPTIONAL_TESTS_FAILING }}
   # To override the endpoint used by fetch-engine to download engines artifacts:
-  # PRISMA_ENGINES_MIRROR: 'https://pub-4c8d0335265c4484a8734643b596ecb2.r2.dev'
+  PRISMA_ENGINES_MIRROR: '' # 'https://pub-4c8d0335265c4484a8734643b596ecb2.r2.dev'
   # These logs will make it easy to verify that `PRISMA_ENGINES_MIRROR` is used
   # DEBUG: 'prisma:fetch-engine*'
   

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,7 @@ env:
   DATABASE_URL_POSTGRES_TEMPLATE: ${{ secrets.DATABASE_URL_POSTGRES_TEMPLATE }}
   NEXT_TELEMETRY_DISABLED: 1
   # To override the endpoint used by fetch-engine to download engines artifacts:
-  # PRISMA_ENGINES_MIRROR: 'https://pub-4c8d0335265c4484a8734643b596ecb2.r2.dev/'
+  PRISMA_ENGINES_MIRROR: '' # 'https://pub-4c8d0335265c4484a8734643b596ecb2.r2.dev/'
   # These logs will make it easy to verify that `PRISMA_ENGINES_MIRROR` is used
   # DEBUG: 'prisma:fetch-engine*'
 


### PR DESCRIPTION
This PR fixes a regression caused by https://github.com/prisma/ecosystem-tests/pull/5108.
This is not the only fix necessary to patch ecosystem-tests' CI, but it's a step in the right direction.

All the `test / docker` and `test / docker-unsupported` suites now succeed ✅.
With this PR, we went from 75 failing checks to 38 failing checks.

---

Part of https://github.com/prisma/team-orm/issues/1217.