### PR TITLE
fix(driver-adapters): let `@renovate` bot ignore `vitest`, downgrade to `vitest@1.5.0`

### DIFF
--- a/driver-adapters-wasm/d1-vitest/package.json
+++ b/driver-adapters-wasm/d1-vitest/package.json
@@ -19,7 +19,7 @@
     "@cloudflare/workers-types": "4.20240614.0",
     "prisma": "5.17.0-dev.10",
     "typescript": "^5.5.0",
-    "vitest": "1.6.0",
+    "vitest": "1.5.0",
     "wrangler": "3.62.0"
   }
 }

--- a/driver-adapters-wasm/d1-vitest/pnpm-lock.yaml
+++ b/driver-adapters-wasm/d1-vitest/pnpm-lock.yaml
@@ -15,7 +15,7 @@ dependencies:
 devDependencies:
   '@cloudflare/vitest-pool-workers':
     specifier: 0.4.7
-    version: 0.4.7(@cloudflare/workers-types@4.20240614.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.6.0)
+    version: 0.4.7(@cloudflare/workers-types@4.20240614.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0)
   '@cloudflare/workers-types':
     specifier: 4.20240614.0
     version: 4.20240614.0
@@ -26,8 +26,8 @@ devDependencies:
     specifier: ^5.5.0
     version: 5.5.2
   vitest:
-    specifier: 1.6.0
-    version: 1.6.0
+    specifier: 1.5.0
+    version: 1.5.0
   wrangler:
     specifier: 3.62.0
     version: 3.62.0(@cloudflare/workers-types@4.20240614.0)
@@ -41,7 +41,7 @@ packages:
       mime: 3.0.0
     dev: true
 
-  /@cloudflare/vitest-pool-workers@0.4.7(@cloudflare/workers-types@4.20240614.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.6.0):
+  /@cloudflare/vitest-pool-workers@0.4.7(@cloudflare/workers-types@4.20240614.0)(@vitest/runner@1.5.0)(@vitest/snapshot@1.5.0)(vitest@1.5.0):
     resolution: {integrity: sha512-fX/qCPsQgi4w2xXpuCtz8LjvcANVC6KYpPDFO6UyhJ4q5F9VhN14CNesS8S8VWARzt8Q5rfVg9JlBysR3/8YQg==}
     peerDependencies:
       '@vitest/runner': 1.3.x - 1.5.x
@@ -56,7 +56,7 @@ packages:
       esbuild: 0.17.19
       miniflare: 3.20240620.0
       semver: 7.6.2
-      vitest: 1.6.0
+      vitest: 1.5.0
       wrangler: 3.62.0(@cloudflare/workers-types@4.20240614.0)
       zod: 3.23.8
     transitivePeerDependencies:
@@ -773,11 +773,11 @@ packages:
       undici-types: 5.26.5
     dev: true
 
-  /@vitest/expect@1.6.0:
-    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
+  /@vitest/expect@1.5.0:
+    resolution: {integrity: sha512-0pzuCI6KYi2SIC3LQezmxujU9RK/vwC1U9R0rLuGlNGcOuDWxqWKu6nUdFsX9tH1WU0SXtAxToOsEjeUn1s3hA==}
     dependencies:
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
       chai: 4.4.1
     dev: true
 
@@ -785,14 +785,6 @@ packages:
     resolution: {integrity: sha512-7HWwdxXP5yDoe7DTpbif9l6ZmDwCzcSIK38kTSIt6CFEpMjX4EpCgT6wUmS0xTXqMI6E/ONmfgRKmaujpabjZQ==}
     dependencies:
       '@vitest/utils': 1.5.0
-      p-limit: 5.0.0
-      pathe: 1.1.2
-    dev: true
-
-  /@vitest/runner@1.6.0:
-    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
-    dependencies:
-      '@vitest/utils': 1.6.0
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
@@ -805,31 +797,14 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/snapshot@1.6.0:
-    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
-    dependencies:
-      magic-string: 0.30.10
-      pathe: 1.1.2
-      pretty-format: 29.7.0
-    dev: true
-
-  /@vitest/spy@1.6.0:
-    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+  /@vitest/spy@1.5.0:
+    resolution: {integrity: sha512-vu6vi6ew5N5MMHJjD5PoakMRKYdmIrNJmyfkhRpQt5d9Ewhw9nZ5Aqynbi3N61bvk9UvZ5UysMT6ayIrZ8GA9w==}
     dependencies:
       tinyspy: 2.2.1
     dev: true
 
   /@vitest/utils@1.5.0:
     resolution: {integrity: sha512-BDU0GNL8MWkRkSRdNFvCUCAVOeHaUlVJ9Tx0TYBZyXaaOTmGtUFObzchCivIBrIwKzvZA7A9sCejVhXM2aY98A==}
-    dependencies:
-      diff-sequences: 29.6.3
-      estree-walker: 3.0.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
-    dev: true
-
-  /@vitest/utils@1.6.0:
-    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -1622,8 +1597,8 @@ packages:
       ufo: 1.5.3
     dev: true
 
-  /vite-node@1.6.0:
-    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
+  /vite-node@1.5.0:
+    resolution: {integrity: sha512-tV8h6gMj6vPzVCa7l+VGq9lwoJjW8Y79vst8QZZGiuRAfijU+EEWuc0kFpmndQrWhMMhet1jdSF+40KSZUqIIw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -1678,15 +1653,15 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.6.0:
-    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+  /vitest@1.5.0:
+    resolution: {integrity: sha512-d8UKgR0m2kjdxDWX6911uwxout6GHS0XaGH1cksSIVVG8kRlE7G7aBw7myKQCvDI5dT4j7ZMa+l706BIORMDLw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 1.6.0
-      '@vitest/ui': 1.6.0
+      '@vitest/browser': 1.5.0
+      '@vitest/ui': 1.5.0
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -1703,11 +1678,11 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@vitest/expect': 1.6.0
-      '@vitest/runner': 1.6.0
-      '@vitest/snapshot': 1.6.0
-      '@vitest/spy': 1.6.0
-      '@vitest/utils': 1.6.0
+      '@vitest/expect': 1.5.0
+      '@vitest/runner': 1.5.0
+      '@vitest/snapshot': 1.5.0
+      '@vitest/spy': 1.5.0
+      '@vitest/utils': 1.5.0
       acorn-walk: 8.3.3
       chai: 4.4.1
       debug: 4.3.5
@@ -1721,7 +1696,7 @@ packages:
       tinybench: 2.8.0
       tinypool: 0.8.4
       vite: 5.3.1
-      vite-node: 1.6.0
+      vite-node: 1.5.0
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,8 @@
     "@prisma/pg-worker",
     "@prisma/adapter-neon",
     "@prisma/adapter-libsql",
-    "@prisma/adapter-d1"
+    "@prisma/adapter-d1",
+    "vitest"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
This PR reverts https://github.com/prisma/ecosystem-tests/pull/5158 and fixes an ecosystem-test regression to https://github.com/prisma/prisma/pull/24554.

Context: [see Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1719925467000479).

The `test / driver-adapters-wasm` test suite now succeeds ✅.

---

Part of https://github.com/prisma/team-orm/issues/1217.