### PR TITLE
fix: heroky-buildpack test

### DIFF
--- a/databases/heroku-pgbouncer-buildpack/package.json
+++ b/databases/heroku-pgbouncer-buildpack/package.json
@@ -9,6 +9,7 @@
     "express": "^4.17.1"
   },
   "scripts": {
+    "build": "prisma generate",
     "start": "node index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Looks like Heroku updated pnpm to not run post-install hooks by default.
Adding explicit build step.
