### PR TITLE
Less verbose notifications for ecosystem-test failures

### DIFF
--- a/.github/scripts/test-project.sh
+++ b/.github/scripts/test-project.sh
@@ -187,17 +187,6 @@ if [ "$GITHUB_REF" = "refs/heads/dev" ] || [ "$GITHUB_REF" = "refs/heads/integra
   export webhook="$SLACK_WEBHOOK_URL"
   version="$(cat .github/prisma-version.txt)"
   sha="$(git rev-parse HEAD | cut -c -7)"
-
-  emoji=":warning:"
-  if [ $code -eq 0 ]; then
-    emoji=":white_check_mark:"
-  fi
-
-  if [ $code -ne 0 ]; then
-    export webhook="$SLACK_WEBHOOK_URL_FAILING"
-    echo "notifying failing slack channel"
-    node .github/slack/notify.js "prisma@$version: ${emoji} $workflow_link failed (via $commit_link)"
-  fi
 fi
 
 echo "exitting with code $code"


### PR DESCRIPTION
Right now, we are retrying ecosystem tests and every failure, we post a
message into #feed-ecosystem-tests-jobs-failures. Since at least one
retry happens almost on every run, channel becomes pretty noisy and
actual failures are easy to overlook.

Final notification to the channel is still happening in
`notify-failure.sh`.
