### PR TITLE
Ensure cf-hyperdrive test does not continue on wrangler errors

### DIFF
--- a/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
+++ b/driver-adapters-wasm/pg-cf-hyperdrive/prepare.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux
+set -euxo pipefail
 
 export TMP_FILE=hyperdrive.tmp
 export PRISMA_TELEMETRY_INFORMATION='ecosystem-tests driver-adapters-wasm pg-cf-hyperdrive build'


### PR DESCRIPTION
Logs are too noisy and it hard to get to original error.
