### PR TITLE
fix(aws-graviton): Cleanup pnpm packages after the test

### DIFF
--- a/platforms/aws-graviton/finally.sh
+++ b/platforms/aws-graviton/finally.sh
@@ -2,5 +2,9 @@
 
 set -eux
 
-ssh -tt -i ./server-key.pem ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com "rm -rf /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID/$PRISMA_CLIENT_ENGINE_TYPE"
+ssh -tt -i ./server-key.pem ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com "
+    rm -rf /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID/$PRISMA_CLIENT_ENGINE_TYPE
+    pnpm cache prune
+"
+
 

--- a/platforms/aws-graviton/finally.sh
+++ b/platforms/aws-graviton/finally.sh
@@ -4,7 +4,9 @@ set -eux
 
 ssh -tt -i ./server-key.pem ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com "
     rm -rf /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID/$PRISMA_CLIENT_ENGINE_TYPE
-    pnpm cache prune
+    # delete parent folder if empty
+    find /home/ec2-user/aws-graviton/$GITHUB_JOB/$GITHUB_RUN_ID -maxdepth 0 -empty -delete
+    pnpm store prune
 "
 
 

--- a/platforms/aws-graviton/run.sh
+++ b/platforms/aws-graviton/run.sh
@@ -12,8 +12,6 @@ ssh -i ./server-key.pem ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com -tt "
     export CI=\"true\"
     export PRISMA_CLIENT_ENGINE_TYPE=\"$PRISMA_CLIENT_ENGINE_TYPE\"
 
-    rm -rf ./node_modules;
-
     npm i -g pnpm@8;
     pnpm -v;
 

--- a/platforms/aws-graviton/sync-from-remote.sh
+++ b/platforms/aws-graviton/sync-from-remote.sh
@@ -10,7 +10,7 @@ echo "Sync: Removing existing local code"
 rm -rf ./code
 
 echo "Sync: Copying remote code from EC2 to local"
-rysnc -Pav -e "ssh -i ./server-key.pem" --exclude "node_modules" ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com:/home/ec2-user/aws-graviton/ .
+rysnc --progress --verbose --archive --rsh="ssh -i ./server-key.pem" --exclude "node_modules" ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com:/home/ec2-user/aws-graviton/ .
 
 echo "Sync: Renaming local aws-graviton/ to code/"
 mv aws-graviton/ code/

--- a/platforms/aws-graviton/sync-from-remote.sh
+++ b/platforms/aws-graviton/sync-from-remote.sh
@@ -9,11 +9,8 @@ echo "Sync: Syncing code from EC2"
 echo "Sync: Removing existing local code"
 rm -rf ./code
 
-echo "Sync: Removing remote node_modules on server"
-ssh -tt -i ./server-key.pem ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com 'rm -rf /home/ec2-user/aws-graviton/node_modules'
-
 echo "Sync: Copying remote code from EC2 to local"
-scp -i ./server-key.pem -rp ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com:/home/ec2-user/aws-graviton/ .
+rysnc -Pav -e "ssh -i ./server-key.pem" --exclude "node_modules" ec2-user@ec2-54-209-135-27.compute-1.amazonaws.com:/home/ec2-user/aws-graviton/ .
 
 echo "Sync: Renaming local aws-graviton/ to code/"
 mv aws-graviton/ code/


### PR DESCRIPTION
We did not really clean up pnpm store after the test, so over the years it accumulated 27 GB worth of packages and the machine ran out of disk space.
Fixed by running `pnpm store prune` in `finally.sh` after removing test project from the machine.

Ideally, we'd just spin up new clean VM for every test, but I am not sure how that affects performance and costs, so doing simpler thing for now.