### PR TITLE
test(aws-graviton): update engine files assertion to include "deno"

### DIFF
--- a/platforms/aws-graviton/code/index.test.js
+++ b/platforms/aws-graviton/code/index.test.js
@@ -49,6 +49,7 @@ describe('Prisma', () => {
 [
   "default.d.ts",
   "default.js",
+  "deno",
   "edge.d.ts",
   "edge.js",
   "index-browser.js",

--- a/platforms/aws-graviton/code/index.test.js
+++ b/platforms/aws-graviton/code/index.test.js
@@ -31,6 +31,7 @@ describe('Prisma', () => {
 [
   "default.d.ts",
   "default.js",
+  "deno",
   "edge.d.ts",
   "edge.js",
   "index-browser.js",


### PR DESCRIPTION
This PR fixes the following - currently failing - ecosystem test:
- test / platforms (aws-graviton, library, ubuntu-20.04)

Context: [Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1722848962315629).