### PR TITLE
test(docker-pgbouncer): fix flakiness by waiting on Docker's services' availabilities instead of 30s

### DIFF
--- a/databases/docker-pgbouncer/docker-compose.yml
+++ b/databases/docker-pgbouncer/docker-compose.yml
@@ -1,6 +1,38 @@
-version: "3.1"
-
 services:
+  # Postgres database.
+  postgres:
+    image: postgres:9.6.24
+    environment:
+      POSTGRES_USER: postgres # define credentials
+      POSTGRES_PASSWORD: postgres # define credentials
+      POSTGRES_DB: postgres # define database
+    ports:
+      - 5433:5432 # Postgres port
+    healthcheck:
+      # specifying user and database is needed to avoid `FATAL:  role "root" does not exist`
+      # spam in the logs
+      test: ['CMD', 'pg_isready', '-U', 'postgres', '-d', 'postgres']
+      interval: 5s
+      timeout: 2s
+      retries: 20
+
+  # Connection pooler for the Postgres database.
+  pgbouncer:
+    image: brainsam/pgbouncer:1.12.0
+    environment:
+      DB_HOST: postgres
+      DB_USER: postgres # define credentials
+      DB_PASSWORD: postgres # define credentials
+      DB_port: 5433 # define database
+      POOL_MODE: "transaction"
+      MAX_CLIENT_CONN: "1000"
+    depends_on:
+      - postgres
+    links:
+      - postgres:postgres
+    ports:
+      - 6433:6432 # PgBouncer port
+
   # pgadmin4 for pgbouncer.
   pgadmin4-master:
     image: fenglc/pgadmin4
@@ -11,26 +43,5 @@ services:
     environment:
       DEFAULT_USER: pgbouncer_database
       DEFAULT_PASSWORD: 12345678
-  # Postgres database.
-  postgres:
-    image: postgres:9.6.24
-    environment:
-      POSTGRES_USER: postgres # define credentials
-      POSTGRES_PASSWORD: postgres # define credentials
-      POSTGRES_DB: postgres # define database
-    ports:
-      - 5433:5432 # Postgres port
-  # Postgres database.
-  pgbouncer:
-    image: brainsam/pgbouncer:1.12.0
-    environment:
-      DB_HOST: postgres
-      DB_USER: postgres # define credentials
-      DB_PASSWORD: postgres # define credentials
-      DB_port: 5433 # define database
-      POOL_MODE: "transaction"
-      MAX_CLIENT_CONN: "1000"
-    links:
-      - postgres:postgres
-    ports:
-      - 6433:6432 # PgBouncer port
+    depends_on:
+      - pgbouncer

--- a/databases/docker-pgbouncer/run.sh
+++ b/databases/docker-pgbouncer/run.sh
@@ -11,4 +11,4 @@ docker compose up -d
 # Wait for services to be healthy
 docker compose up --wait
 
-docker container exec -i $(docker-compose ps -q postgres) psql -U postgres < data.sql
+docker container exec -i $(docker compose ps -q postgres) psql -U postgres < data.sql

--- a/databases/docker-pgbouncer/run.sh
+++ b/databases/docker-pgbouncer/run.sh
@@ -7,5 +7,8 @@ pnpm prisma generate
 
 # Start database and import data
 docker compose up -d
-sleep 30
+
+# Wait for services to be healthy
+docker compose up --wait
+
 docker container exec -i $(docker-compose ps -q postgres) psql -U postgres < data.sql


### PR DESCRIPTION
This PR fixes the following - currently failing - ecosystem tests:
- `test / databases (docker-pgbouncer, library, ubuntu-20.04)`
- `test / databases (docker-pgbouncer, binary, ubuntu-20.04)`

Context: [Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1722848962315629).