### PR TITLE
feat(docker): fix BINARY regression test for https://github.com/prisma/prisma/issues/25101

### DIFF
--- a/docker/ubuntu-22.04-amd64-openssl-1.1.x/run.sh
+++ b/docker/ubuntu-22.04-amd64-openssl-1.1.x/run.sh
@@ -3,14 +3,6 @@
 set -eux
 export DEBUG="*"
 
-PRISMA_TELEMETRY_INFORMATION=""
-CI="false"
-PRISMA_CLIENT_ENGINE_TYPE="library"
-PRISMA_ENGINES_MIRROR="https://binaries.prisma.sh"
-
-DOCKER_PLATFORM_ARCH="linux/amd64"
-PRISMA_DOCKER_IMAGE_NAME="prisma-ubuntu-22.04-amd64-openssl-1.1.x"
-
 docker buildx build --load \
   --platform="${DOCKER_PLATFORM_ARCH}" \
   --build-context app=. \


### PR DESCRIPTION
In https://github.com/prisma/ecosystem-tests/pull/5424, I had accidentally committed some hardcoded variables in `run.sh`, which were accidentally not discovered during the review. This caused this failure: https://github.com/prisma/ecosystem-tests/actions/runs/10682346172/job/29608081092#step:10:2740.