### PR TITLE
fix: skip lib check in firebase

### DIFF
--- a/platforms-serverless/firebase-functions/firebase.json
+++ b/platforms-serverless/firebase-functions/firebase.json
@@ -1,6 +1,6 @@
 {
   "functions": {
-    "codebase": "firebase-functions"
-  },
-  "runtime": "nodejs22"
+    "codebase": "firebase-functions",
+    "runtime": "nodejs22"
+  }
 }

--- a/platforms-serverless/firebase-functions/firebase.json
+++ b/platforms-serverless/firebase-functions/firebase.json
@@ -1,5 +1,6 @@
 {
   "functions": {
     "codebase": "firebase-functions"
-  }
+  },
+  "runtime": "nodejs22"
 }

--- a/platforms-serverless/firebase-functions/functions/tsconfig.json
+++ b/platforms-serverless/firebase-functions/functions/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": ".",
     "strict": true,
     "lib": ["esnext", "dom"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Fixes [platforms-serverless (firebase-functions, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13635088549/job/38112023011#logs)

It's still failing but for another reason now (expired token?)