### PR TITLE
fix: enable nodejs compat in cf

### DIFF
--- a/driver-adapters-wasm/d1-cf-basic/wrangler.base.toml
+++ b/driver-adapters-wasm/d1-cf-basic/wrangler.base.toml
@@ -1,6 +1,7 @@
 name = "d1-cf-basic"
 main = "src/index.js"
 compatibility_date = "2023-10-30"
+compatibility_flags = [ "nodejs_compat" ]
 
 [[d1_databases]]
 binding = "MY_DATABASE"    # i.e. available in the Worker on env.MY_DATABASE

--- a/driver-adapters-wasm/d1-cfpages-basic/wrangler.toml
+++ b/driver-adapters-wasm/d1-cfpages-basic/wrangler.toml
@@ -1,6 +1,7 @@
 name = "d1-cfpages-basic"
 main = "src/index.js"
 compatibility_date = "2023-10-30"
+compatibility_flags = [ "nodejs_compat" ]
 
 [[d1_databases]]
 binding = "MY_DATABASE"    # i.e. available in the Worker on env.MY_DATABASE


### PR DESCRIPTION
Fixes
[driver-adapters-wasm (d1-cf-basic, wasm, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122268563#logs)
[driver-adapters-wasm (d1-cfpages-basic, wasm, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122268876#logs)

Might be unnecessary if https://github.com/prisma/prisma/pull/26485 works