### PR TITLE
fix(engines): fix `engine (engine-native-deps)`

### DIFF
--- a/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,9 +1,7 @@
 ld-linux-x86-64.so.2
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/query-engine.txt
@@ -1,8 +1,6 @@
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/debian-openssl-1.1.x/schema-engine.txt
@@ -1,8 +1,6 @@
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,8 +1,6 @@
 ld-linux-aarch64.so.1
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/query-engine.txt
@@ -1,8 +1,6 @@
 ld-linux-aarch64.so.1
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-arm64-openssl-1.1.x/schema-engine.txt
@@ -1,8 +1,6 @@
 ld-linux-aarch64.so.1
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,4 +1,2 @@
-libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/query-engine.txt
@@ -1,4 +1,2 @@
-libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl-arm64-openssl-1.1.x/schema-engine.txt
@@ -1,4 +1,2 @@
-libcrypto.so.1.1
 libc.so
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl/libquery_engine.so.node.txt
@@ -1,4 +1,2 @@
 libc.musl-x86_64.so.1
-libcrypto.so.1.1
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl/query-engine.txt
@@ -1,4 +1,2 @@
 libc.musl-x86_64.so.1
-libcrypto.so.1.1
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/linux-musl/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/linux-musl/schema-engine.txt
@@ -1,4 +1,2 @@
 libc.musl-x86_64.so.1
-libcrypto.so.1.1
 libgcc_s.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/libquery_engine.so.node.txt
+++ b/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/libquery_engine.so.node.txt
@@ -1,9 +1,7 @@
 ld-linux-x86-64.so.2
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/query-engine.txt
+++ b/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/query-engine.txt
@@ -1,8 +1,6 @@
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1

--- a/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/schema-engine.txt
+++ b/engines/engine-native-deps/snapshots/rhel-openssl-1.1.x/schema-engine.txt
@@ -1,8 +1,6 @@
-libcrypto.so.1.1
 libc.so.6
 libdl.so.2
 libgcc_s.so.1
 libm.so.6
 libpthread.so.0
 librt.so.1
-libssl.so.1.1


### PR DESCRIPTION
This PR:
- closes [ORM-772](https://linear.app/prisma-company/issue/ORM-772/fix-engines-ecosystem-tests)
- fixes the `engine (engine-native-deps)` test suite, whose snapshot assertions were broken by https://github.com/prisma/prisma-engines/pull/5209