### PR TITLE
fix: rhel-openssl-3.0.x target in serverless lambda

### DIFF
--- a/platforms-serverless/serverless-framework-lambda/prisma/schema.prisma
+++ b/platforms-serverless/serverless-framework-lambda/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "rhel-openssl-1.0.x"]
+  binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {
@@ -9,7 +9,7 @@ datasource db {
 }
 
 model User {
-  id    String  @default(cuid()) @id
+  id    String  @id @default(cuid())
   email String  @unique
   name  String?
 }


### PR DESCRIPTION
FIxes [platforms-serverless (serverless-framework-lambda, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122290354#logs)