### PR TITLE
fix: set pnpm version in heroku

### DIFF
--- a/platforms/heroku/package.json
+++ b/platforms/heroku/package.json
@@ -15,5 +15,6 @@
   "dependencies": {
     "@prisma/client": "6.5.0-dev.50",
     "express": "^4.17.1"
-  }
+  },
+  "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
 }


### PR DESCRIPTION
Fixes [platforms (heroku, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122268207#logs)