### PR TITLE
fix: specify node version for vercel-builder

### DIFF
--- a/platforms-serverless-vercel/vercel-node-builder/package.json
+++ b/platforms-serverless-vercel/vercel-node-builder/package.json
@@ -17,5 +17,8 @@
   "scripts": {
     "start": "node index.js",
     "postinstall": "pnpm prisma generate"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }

--- a/platforms-serverless-vercel/vercel-node-builder/test.sh
+++ b/platforms-serverless-vercel/vercel-node-builder/test.sh
@@ -4,9 +4,9 @@ set -eux
 DEPLOYED_URL=$( tail -n 1 deployment-url.txt )
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url $DEPLOYED_URL --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string ${files}


### PR DESCRIPTION
Fixes [platforms-serverless-vercel (vercel-node-builder, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122281013#logs)