### PR TITLE
fix: specify node version for vercel cli

### DIFF
--- a/platforms-serverless-vercel/vercel-cli/package.json
+++ b/platforms-serverless-vercel/vercel-cli/package.json
@@ -16,5 +16,8 @@
   "scripts": {
     "start": "node index.js",
     "postinstall": "prisma generate"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }

--- a/platforms-serverless-vercel/vercel-cli/test.sh
+++ b/platforms-serverless-vercel/vercel-cli/test.sh
@@ -4,12 +4,12 @@ set -eux
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
   echo "Binary"
-  files=',"files":["default.js","index.js","package.json","query-engine-rhel-openssl-1.0.x","schema.prisma"]'
+  files=',"files":["default.js","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma"]'
   # TODO Use deployment, not production
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-vercel-api-binary.vercel.app/api --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 else
   echo "Library (Default)"
-  files=',"files":["default.js","index.js","libquery_engine-rhel-openssl-1.0.x.so.node","package.json","schema.prisma"]'
+  files=',"files":["default.js","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma"]'
   # TODO Use deployment, not production
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-vercel-api.vercel.app/api --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 fi


### PR DESCRIPTION
Fixes [platforms-serverless-vercel (vercel-cli, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13638263500/job/38122280656#logs)