### PR TITLE
fix: skip yarn corepack check in core-features

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -859,6 +859,8 @@ jobs:
         clientEngine: ['library', 'binary']
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
+    env:
+      SKIP_YARN_COREPACK_CHECK: 1
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fixes
[core-features (generate-client-and-cli-install-via-global-cli-yarn-lockfile, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166440768#logs)
[core-features (generate-client-and-cli-install-via-global-cli-yarn-lockfile, binary, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166443733#logs)
[core-features (generate-client-install-yarn, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166455744#logs)
[core-features (generate-client-install-yarn, binary, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166460247#logs)
[core-features (generate-client-install-on-sub-project-yarn, library, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166474504#logs)
[core-features (generate-client-install-on-sub-project-yarn, binary, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166476461#logs)