### PR TITLE
fix: specify node version for accelerate vercel

### DIFF
--- a/accelerate/vercel-cli-serverless-functions/package.json
+++ b/accelerate/vercel-cli-serverless-functions/package.json
@@ -25,5 +25,8 @@
   "scripts": {
     "test": "jest",
     "postinstall": "prisma generate --data-proxy"
+  },
+  "engines": {
+    "node": "22.x"
   }
 }


### PR DESCRIPTION
Fixes
[accelerate (vercel-cli-serverless-functions, <accelerate>, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13653197576/job/38166626104#logs)