### PR TITLE
fix: fix random nodejs tracing failures

### DIFF
--- a/accelerate/nodejs-tracing/index.test.ts
+++ b/accelerate/nodejs-tracing/index.test.ts
@@ -55,7 +55,7 @@ function cleanSpansForSnapshot(spans: ReadableSpan[]) {
   const sortedSpans = spans.sort((a, b) => a.name.localeCompare(b.name, 'en-US'))
 
   // Remove spans about "SELECT 1" query which is sometimes issued and sometimes isn't
-  const filteredSpans = sortedSpans.filter((span) => span.attributes?.['db.statement'] !== 'SELECT 1')
+  const filteredSpans = sortedSpans.filter((span) => span.attributes?.['db.query.text'] !== 'SELECT 1')
 
   return JSON.parse(
     JSON.stringify(filteredSpans, (key, value) => {


### PR DESCRIPTION
A select 1 query seems to cause random failures on dev: [accelerate (nodejs-tracing, <accelerate>, ubuntu-20.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13654252802/job/38169920262#logs)