### PR TITLE
fix: add an npmrc that disables side effect cache

### DIFF
--- a/platforms-serverless/netlify-github-with-nextjs-caching/.npmrc
+++ b/platforms-serverless/netlify-github-with-nextjs-caching/.npmrc
@@ -1,0 +1,1 @@
+side-effects-cache = false

--- a/platforms-serverless/netlify-github-with-nextjs-caching/package.json
+++ b/platforms-serverless/netlify-github-with-nextjs-caching/package.json
@@ -19,5 +19,11 @@
     "node-fetch": "2.7.0",
     "react": "18.3.1",
     "react-dom": "18.3.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "prisma",
+      "@prisma/client"
+    ]
   }
 }

--- a/platforms-serverless/netlify-github-with-nextjs-caching/package.json
+++ b/platforms-serverless/netlify-github-with-nextjs-caching/package.json
@@ -22,7 +22,6 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "prisma",
       "@prisma/client"
     ]
   }


### PR DESCRIPTION
Fixes [platforms-serverless (netlify-github-with-nextjs-caching, library, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13657259829/job/38179781400#logs)