### PR TITLE
fix: add an npmrc that disables side effect cache

### DIFF
--- a/platforms-serverless-vercel/vercel-with-nextjs-caching/.npmrc
+++ b/platforms-serverless-vercel/vercel-with-nextjs-caching/.npmrc
@@ -1,0 +1,1 @@
+side-effects-cache = false


### PR DESCRIPTION
Fixes [platforms-serverless-vercel (vercel-with-nextjs-caching, library, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13657259829/job/38179754355#logs)