### PR TITLE
fix: unbreak `debian-bullseye-amd64-openssl-1.1.x-tls`

### DIFF
--- a/docker/debian-bullseye-amd64-openssl-1.1.x-tls/run.sh
+++ b/docker/debian-bullseye-amd64-openssl-1.1.x-tls/run.sh
@@ -20,7 +20,9 @@ if [ ! -f "server-ca.pem" ]; then
     echo "$GCP_POSTGRESQL_SSL_SERVER_CA" >> server-ca.pem
 fi
 
-openssl pkcs12 -export -out client-identity.p12 -inkey client-key.pem -in client-cert.pem -password pass:prisma
+openssl pkcs12 -export -out client-identity.p12 \
+  -inkey client-key.pem -in client-cert.pem -password pass:prisma \
+  -keypbe AES-256-CBC -certpbe AES-256-CBC -macalg SHA256
 
 docker buildx build --load \
   --platform="${DOCKER_PLATFORM_ARCH}" \


### PR DESCRIPTION
Use a modern AES-256 cipher to encrypt the PKCS#12 certificate file.

The OpenSSL CLI installed in this container is OpenSSL 1.1, which notoriously has bad and insecure defaults. In this case, it defaults to ancient RC2 cipher that should not be used in this age. The same command with OpenSSL 3 would use AES-256 by default.

The reason we need to change this is because the engines compiled for this target now use vendored OpenSSL 3, which does not support dangerous outdated algorithms by default. The version we vendor does actually compile in support for them (`legacy` cargo feature of `openssl-src` is enabled in `openssl-sys` by default) but OpenSSL still refuses to use them unless either we load the legacy providers programmatically, or the user sets the `OPENSSL_CONF` environment variable to point at a configuration file that loads the legacy providers. It may look like this:

```ini
.include /etc/ssl/openssl.cnf   ; include the standard config (path may vary)
[provider_sect]
default = default_sect
legacy = legacy_sect

[default_sect]
activate = 1

[legacy_sect]
activate = 1
```

Refs: https://linear.app/prisma-company/issue/ORM-770/fix-docker-tests