### PR TITLE
fix: get libsql to work on lambda

### DIFF
--- a/driver-adapters/turso-lambda-basic/index.js
+++ b/driver-adapters/turso-lambda-basic/index.js
@@ -1,6 +1,6 @@
 // @ts-check
 const { Prisma, PrismaClient } = require('@prisma/client')
-const { createClient } = require('@libsql/client/web')
+const { createClient } = require('@libsql/client')
 const { PrismaLibSQL } = require('@prisma/adapter-libsql')
 
 const connectionString = process.env.DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -15,7 +15,7 @@ GENERATED_CLIENT=$(node -e "
   )
 ")
 
-pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:libsql/client
+pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:@libsql/client
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
 

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -15,12 +15,9 @@ GENERATED_CLIENT=$(node -e "
   )
 ")
 
-pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:@libsql/client
+pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --alias:'@libsql/client/node=@libsql/client/web'
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
-
-mkdir -p dist/node_modules/@libsql/client
-cp -r node_modules/@libsql/client dist/node_modules/@libsql/client
 
 zip -rj lambda.zip dist
 

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -15,7 +15,7 @@ GENERATED_CLIENT=$(node -e "
   )
 ")
 
-pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs
+pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:libsql
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
 zip -rj lambda.zip dist

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -15,7 +15,7 @@ GENERATED_CLIENT=$(node -e "
   )
 ")
 
-pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:libsql
+pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:libsql/client
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
 

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -15,7 +15,7 @@ GENERATED_CLIENT=$(node -e "
   )
 ")
 
-pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --alias:'@libsql/client/node=@libsql/client/web'
+pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --alias:'@libsql/client=@libsql/client/web'
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
 

--- a/driver-adapters/turso-lambda-basic/run.sh
+++ b/driver-adapters/turso-lambda-basic/run.sh
@@ -18,6 +18,10 @@ GENERATED_CLIENT=$(node -e "
 pnpm esbuild index.js --bundle --platform=node --target=node18 --outfile=dist/index.js --format=cjs --external:libsql
 cp "$GENERATED_CLIENT"/libquery_engine-rhel-openssl-1.0.x.so.node dist
 cp "$GENERATED_CLIENT"/schema.prisma dist
+
+mkdir -p dist/node_modules/@libsql/client
+cp -r node_modules/@libsql/client dist/node_modules/@libsql/client
+
 zip -rj lambda.zip dist
 
 aws lambda update-function-configuration --function-name driver-adapters-turso-lambda-basic --runtime nodejs18.x --environment "Variables={DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL,DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN}" --timeout 30


### PR DESCRIPTION
Turso, when imported via the default `libsq/client` and built with esbuild doesn't work on lambdas. [There's an open issue for it](https://github.com/tursodatabase/libsql-client-ts/issues/112). There is a workaround though - importing `libsql/client/web` directly, but it doesn't work when other packages import libsql as well, and they do in our case (like our adapter). I've managed to get it to work through a hacky esbuild alias `--alias:'@libsql/client=@libsql/client/web'`.

Fixes [driver-adapters (turso-lambda-basic, library, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13680152516/job/38250207569?pr=5907#logs)