### PR TITLE
fix: update bundle file assertions

### DIFF
--- a/platforms-serverless-vercel/vercel-node-builder/test.sh
+++ b/platforms-serverless-vercel/vercel-node-builder/test.sh
@@ -4,9 +4,9 @@ set -eux
 DEPLOYED_URL=$( tail -n 1 deployment-url.txt )
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url $DEPLOYED_URL --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string ${files}

--- a/platforms-serverless-vercel/vercel-with-redwood/index.test.js
+++ b/platforms-serverless-vercel/vercel-with-redwood/index.test.js
@@ -47,6 +47,8 @@ test('should test .prisma/client files', async () => {
   const files =
     process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary'
       ? [
+          'client.d.ts',
+          'client.js',
           'default.d.ts',
           'default.js',
           'deno',
@@ -62,6 +64,8 @@ test('should test .prisma/client files', async () => {
           'wasm.js',
         ]
       : [
+          'client.d.ts',
+          'client.js',
           'default.d.ts',
           'default.js',
           'deno',

--- a/platforms-serverless/azure-functions-linux/test.sh
+++ b/platforms-serverless/azure-functions-linux/test.sh
@@ -6,9 +6,9 @@ app="$(cat func-tmp.txt)"
 url="https://$app.azurewebsites.net/api/$app"
 prisma_version="$(cat ../../.github/prisma-version.txt)"
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 expected='{"version":"'$prisma_version'","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}'${files}'}'
 actual=$(curl "$url")

--- a/platforms-serverless/firebase-functions/test.sh
+++ b/platforms-serverless/firebase-functions/test.sh
@@ -7,9 +7,9 @@ url="https://us-central1-prisma-e2e-tests-265911.cloudfunctions.net/$func"
 prisma_version="$(cat ../../.github/prisma-version.txt)"
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 expected='{"version":"'$prisma_version'","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}'${files}'}'

--- a/platforms-serverless/gcp-functions/test.sh
+++ b/platforms-serverless/gcp-functions/test.sh
@@ -7,9 +7,9 @@ url="https://us-central1-prisma-e2e-tests-265911.cloudfunctions.net/$func"
 prisma_version="$(cat ../../.github/prisma-version.txt)"
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 expected='{"version":"'$prisma_version'","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}'${files}'}'

--- a/platforms-serverless/lambda-node-20/test.ts
+++ b/platforms-serverless/lambda-node-20/test.ts
@@ -19,9 +19,9 @@ async function main() {
   const actual = JSON.stringify(original)
   console.log('actual', actual)
   // TODO Update to only expect on engine file after zip script was updated
-  let files = `,"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]`
+  let files = `,"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-1.1.x.so.node","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]`
   if (process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary') {
-    files = `,"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]`
+    files = `,"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-1.1.x","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]`
   }
 
   const expect =

--- a/platforms-serverless/netlify-cli/test.sh
+++ b/platforms-serverless/netlify-cli/test.sh
@@ -3,9 +3,9 @@
 set -eux
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  BINARY_STRING=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
+  BINARY_STRING=',"files":["client.d.ts","client.js","default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  BINARY_STRING=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
+  BINARY_STRING=',"files":["client.d.ts","client.js","default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 # TODO Use individual deployment URL

--- a/platforms-serverless/netlify-github/test.sh
+++ b/platforms-serverless/netlify-github/test.sh
@@ -5,9 +5,9 @@ set -eux
 ID=$( tail -n 1 id.txt )
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]'
 else
-  files=',"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]'
 fi
 
 pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://$ID--prisma-ecosystem-tests-netlify-github.netlify.app/.netlify/functions/index --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files

--- a/platforms-serverless/serverless-framework-lambda/test.ts
+++ b/platforms-serverless/serverless-framework-lambda/test.ts
@@ -10,9 +10,10 @@ async function main() {
   console.log({ data: data.$response.data })
 
   const actual = (data.$response.data as any).Payload
-  const binaryString = process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary'
-    ? `,"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]`
-    : `,"files":["default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]`
+  const binaryString =
+    process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary'
+      ? `,"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-rhel-openssl-3.0.x","schema.prisma","wasm.d.ts","wasm.js"]`
+      : `,"files":["client.d.ts","client.js","default.d.ts","default.js","deno","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-rhel-openssl-3.0.x.so.node","package.json","schema.prisma","wasm.d.ts","wasm.js"]`
   const expect = `{"version":"${Prisma.prismaVersion.client}","createUser":{"id":"12345","email":"alice@prisma.io","name":"Alice"},"updateUser":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"users":{"id":"12345","email":"bob@prisma.io","name":"Bob"},"deleteManyUsers":{"count":1}${binaryString}}`
 
   if (actual !== expect) {

--- a/platforms/aws-graviton/code/index.test.js
+++ b/platforms/aws-graviton/code/index.test.js
@@ -29,6 +29,8 @@ describe('Prisma', () => {
     if (process.env.PRISMA_CLIENT_ENGINE_TYPE !== 'binary') {
       expect(files).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "deno",
@@ -47,6 +49,8 @@ describe('Prisma', () => {
     } else {
       expect(files).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "deno",

--- a/platforms/heroku/test.sh
+++ b/platforms/heroku/test.sh
@@ -3,10 +3,9 @@
 set -eux
 
 if [ "$PRISMA_CLIENT_ENGINE_TYPE" == "binary" ]; then
-  files=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","package.json","query-engine-debian-openssl-3.0.x","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-platforms-heroku-binary.herokuapp.com --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 else
-  files=',"files":["default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
+  files=',"files":["client.d.ts","client.js","default.d.ts","default.js","edge.d.ts","edge.js","index-browser.js","index.d.ts","index.js","libquery_engine-debian-openssl-3.0.x.so.node","package.json","runtime","schema.prisma","wasm.d.ts","wasm.js"]'
   pnpm ts-node ../../utils/fetch-retry-and-confirm-version.ts --url https://e2e-platforms-heroku.herokuapp.com --prisma-version $(sh ../../utils/prisma_version.sh) --binary-string $files
 fi
-

--- a/test-runners/jest-with-multiple-generators/src/__tests__/the.test.ts
+++ b/test-runners/jest-with-multiple-generators/src/__tests__/the.test.ts
@@ -35,6 +35,8 @@ describe('Prisma in jest with multiple generators', () => {
     if (process.env.PRISMA_CLIENT_ENGINE_TYPE === 'binary') {
       expect(filesA).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "edge.d.ts",
@@ -52,6 +54,8 @@ describe('Prisma in jest with multiple generators', () => {
 `)
       expect(filesB).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "edge.d.ts",
@@ -70,6 +74,8 @@ describe('Prisma in jest with multiple generators', () => {
     } else {
       expect(filesA).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "edge.d.ts",
@@ -87,6 +93,8 @@ describe('Prisma in jest with multiple generators', () => {
 `)
       expect(filesB).toMatchInlineSnapshot(`
 [
+  "client.d.ts",
+  "client.js",
   "default.d.ts",
   "default.js",
   "edge.d.ts",


### PR DESCRIPTION
Updates assertions to allow client files in the bundles

Fixes [platforms-serverless (lambda-node-20, library, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/13991192039/job/39175561736#logs) and a lot of others