### PR TITLE
fix(scripts): run update scripts for deno projects

### DIFF
--- a/accelerate/deno/deno.json
+++ b/accelerate/deno/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "prisma": "npm:prisma@6.6.0-dev.109",
-    "@prisma/client": "npm:@prisma/client@6.6.0-dev.109",
+    "prisma": "npm:prisma@6.6.0-dev.111",
+    "@prisma/client": "npm:@prisma/client@6.6.0-dev.111",
     "@prisma/extension-accelerate": "npm:@prisma/extension-accelerate@1.2.2",
     "@std/assert": "jsr:@std/assert@^1.0.12"
   },

--- a/accelerate/deno/deno.lock
+++ b/accelerate/deno/deno.lock
@@ -3,9 +3,9 @@
   "specifiers": {
     "jsr:@std/assert@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.6": "1.0.6",
-    "npm:@prisma/client@6.6.0-dev.109": "6.6.0-dev.109_prisma@6.6.0-dev.109",
-    "npm:@prisma/extension-accelerate@1.2.2": "1.2.2_@prisma+client@6.6.0-dev.109__prisma@6.6.0-dev.109_prisma@6.6.0-dev.109",
-    "npm:prisma@6.6.0-dev.109": "6.6.0-dev.109"
+    "npm:@prisma/client@6.6.0-dev.111": "6.6.0-dev.111_prisma@6.6.0-dev.111",
+    "npm:@prisma/extension-accelerate@1.2.2": "1.2.2_@prisma+client@6.6.0-dev.111__prisma@6.6.0-dev.111_prisma@6.6.0-dev.111",
+    "npm:prisma@6.6.0-dev.111": "6.6.0-dev.111"
   },
   "jsr": {
     "@std/assert@1.0.12": {
@@ -94,27 +94,27 @@
     "@esbuild/win32-x64@0.25.2": {
       "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="
     },
-    "@prisma/client@6.6.0-dev.109_prisma@6.6.0-dev.109": {
-      "integrity": "sha512-CA1XTIVv5dPKGD7W2RGXsSBA5AfZJl4DKNI3zyiimuXP1769LdtrwNsYldHun9quSp2GezySVkKNS7tzG/jCag==",
+    "@prisma/client@6.6.0-dev.111_prisma@6.6.0-dev.111": {
+      "integrity": "sha512-FF1VwMhhaYT0QMdmlKGIuAyTQJu5GVIC9NPBPfXBYb6YsAOHfmeN6A3pD+PgJsnKA1X9w/9XgaQHmvnHpch/kA==",
       "dependencies": [
         "prisma"
       ]
     },
-    "@prisma/config@6.6.0-dev.109_esbuild@0.25.2": {
-      "integrity": "sha512-AUyp3wC0gWyAuEET5yPlmg36HkvpP4RzhGjYpeHqOLIFxu5CodKn33xwGiWVibRY+up4PW9+VHRGgobNC0K5nQ==",
+    "@prisma/config@6.6.0-dev.111_esbuild@0.25.2": {
+      "integrity": "sha512-eCbBrAI+VigzuSENiRzs0wJDx50DbcxtJ55dEjcpOLAkMZtCuDB0VQq2bDXOKs1dp4IZZduTJKjH8HKFDccGjQ==",
       "dependencies": [
         "esbuild",
         "esbuild-register"
       ]
     },
-    "@prisma/debug@6.6.0-dev.109": {
-      "integrity": "sha512-CQukcfYmrkf5kBQgFJHVhTQLfWBQITl5npLD3rjsJ2PuUHaHE9LjPeRB0S8YRyE3WudV238G3fI48VKLnq3Eyg=="
+    "@prisma/debug@6.6.0-dev.111": {
+      "integrity": "sha512-rsu/BHmftl0alibrZnqJjD+BHus57G40/7PsDWJyM61HAxSTT0hGAHLuEY75wilrPI+twkQAQDMVCVOpdx5Ldw=="
     },
-    "@prisma/engines-version@6.6.0-51.febd1ffa43a7b889647e64817771658dbc24db24": {
-      "integrity": "sha512-ERURCas/tlTytYdaCrtWH7auPAKn9APRIGD6m9xqrmCJx9zcncwg0BCrHvegzxdybodnxECImlseeLU9H6ApyA=="
+    "@prisma/engines-version@6.6.0-52.30389eb8d83fe5c09a7d1d1648e7d5ab7438d1de": {
+      "integrity": "sha512-adHBtZOCvtyqlb1TVQHzz4vA3HGMXjHDy5CXF0KSuTvSXx3k01dQbez7z8PMDfiva0ZZl4INPFbkazCyMkE4fw=="
     },
-    "@prisma/engines@6.6.0-dev.109": {
-      "integrity": "sha512-v/Ewhyx8RXUf/U7WBSEP497aYTLgkkMRJpel8rDedryAtUHOQjzex9N1dOQZGl7DuW8UqgzZOGwYDM8uJ/XvGg==",
+    "@prisma/engines@6.6.0-dev.111": {
+      "integrity": "sha512-PmEc0sPSwkBqiudJVoUbpaxloc9f6NcAZyEH6PsM49xwxfpEADaG5WjGWck2soDn+so8uwcRy4yru8f5murEZQ==",
       "dependencies": [
         "@prisma/debug",
         "@prisma/engines-version",
@@ -122,22 +122,22 @@
         "@prisma/get-platform"
       ]
     },
-    "@prisma/extension-accelerate@1.2.2_@prisma+client@6.6.0-dev.109__prisma@6.6.0-dev.109_prisma@6.6.0-dev.109": {
+    "@prisma/extension-accelerate@1.2.2_@prisma+client@6.6.0-dev.111__prisma@6.6.0-dev.111_prisma@6.6.0-dev.111": {
       "integrity": "sha512-LOlfkG6If+o8PFRzLzp26ackP/d+j2HrkTJaxuV/Wd+sdAHz/AkmzEDGbo2UpHFpxEM9hWMBe3ScSwUKYUDOXg==",
       "dependencies": [
         "@prisma/client"
       ]
     },
-    "@prisma/fetch-engine@6.6.0-dev.109": {
-      "integrity": "sha512-TZxAuwZkkucEwGwlwHqfL4V1q41r7nu4nSOJYbEYpUVjQmvCU8l677Ak++iIiFqxn5euU1PdfuYlVd0ONSp/QQ==",
+    "@prisma/fetch-engine@6.6.0-dev.111": {
+      "integrity": "sha512-TOK5qipRknIGcDTLO9DQje++3+jEDDKgNxpfltG9b3tUnuWT0hnrgLhnfCoyVm+2wWCi0DW9DnJ1K999g8TZnA==",
       "dependencies": [
         "@prisma/debug",
         "@prisma/engines-version",
         "@prisma/get-platform"
       ]
     },
-    "@prisma/get-platform@6.6.0-dev.109": {
-      "integrity": "sha512-xSSMq8EevRkSFRAIQUeiIB87iVW3ZEs2q7Crb4z0v0SE1kZHsSAeNAgmTvJQNUm9PMOpjS3wwsUw7Da/AJYUzQ==",
+    "@prisma/get-platform@6.6.0-dev.111": {
+      "integrity": "sha512-AAWMZQQv9Xq5l0b2WEUbwcV/g7kbHLIw+MRtmaIwHNfwQR7wm2wIRpi+1754gDYDhQaOmcOt1DvAY6v4YU6XHQ==",
       "dependencies": [
         "@prisma/debug"
       ]
@@ -191,8 +191,8 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "prisma@6.6.0-dev.109": {
-      "integrity": "sha512-dRWzcuRAUEYZnpKmPW0rmQGBejMig4+/nfQmuQVca5E627SNsspsquAmUJzjbi17r8c91kOWYm/OgsbVnH5cbw==",
+    "prisma@6.6.0-dev.111": {
+      "integrity": "sha512-KfRQvYF6cgrWqoZah6+fdeRxEaFds4E28htlFvA2JFzbzHYlzfazJO7+WjKju9PrqBIiZWM3CZd5vHeCV9Io0A==",
       "dependencies": [
         "@prisma/config",
         "@prisma/engines",
@@ -203,9 +203,9 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.12",
-      "npm:@prisma/client@6.6.0-dev.109",
+      "npm:@prisma/client@6.6.0-dev.111",
       "npm:@prisma/extension-accelerate@1.2.2",
-      "npm:prisma@6.6.0-dev.109"
+      "npm:prisma@6.6.0-dev.111"
     ]
   }
 }

--- a/runtimes/deno/deno.json
+++ b/runtimes/deno/deno.json
@@ -1,7 +1,7 @@
 {
   "imports": {
-    "prisma": "npm:prisma@6.6.0-dev.109",
-    "@prisma/client": "npm:@prisma/client@6.6.0-dev.109",
+    "prisma": "npm:prisma@6.6.0-dev.111",
+    "@prisma/client": "npm:@prisma/client@6.6.0-dev.111",
     "@std/assert": "jsr:@std/assert@^1.0.12"
   },
   "nodeModulesDir": "auto",

--- a/runtimes/deno/deno.lock
+++ b/runtimes/deno/deno.lock
@@ -4,9 +4,9 @@
     "jsr:@std/assert@*": "1.0.12",
     "jsr:@std/assert@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.6": "1.0.6",
-    "npm:@prisma/client@6.6.0-dev.109": "6.6.0-dev.109_prisma@6.6.0-dev.109",
+    "npm:@prisma/client@6.6.0-dev.111": "6.6.0-dev.111_prisma@6.6.0-dev.111",
     "npm:@types/node@*": "22.12.0",
-    "npm:prisma@6.6.0-dev.109": "6.6.0-dev.109"
+    "npm:prisma@6.6.0-dev.111": "6.6.0-dev.111"
   },
   "jsr": {
     "@std/assert@1.0.12": {
@@ -95,27 +95,27 @@
     "@esbuild/win32-x64@0.25.2": {
       "integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA=="
     },
-    "@prisma/client@6.6.0-dev.109_prisma@6.6.0-dev.109": {
-      "integrity": "sha512-CA1XTIVv5dPKGD7W2RGXsSBA5AfZJl4DKNI3zyiimuXP1769LdtrwNsYldHun9quSp2GezySVkKNS7tzG/jCag==",
+    "@prisma/client@6.6.0-dev.111_prisma@6.6.0-dev.111": {
+      "integrity": "sha512-FF1VwMhhaYT0QMdmlKGIuAyTQJu5GVIC9NPBPfXBYb6YsAOHfmeN6A3pD+PgJsnKA1X9w/9XgaQHmvnHpch/kA==",
       "dependencies": [
         "prisma"
       ]
     },
-    "@prisma/config@6.6.0-dev.109_esbuild@0.25.2": {
-      "integrity": "sha512-AUyp3wC0gWyAuEET5yPlmg36HkvpP4RzhGjYpeHqOLIFxu5CodKn33xwGiWVibRY+up4PW9+VHRGgobNC0K5nQ==",
+    "@prisma/config@6.6.0-dev.111_esbuild@0.25.2": {
+      "integrity": "sha512-eCbBrAI+VigzuSENiRzs0wJDx50DbcxtJ55dEjcpOLAkMZtCuDB0VQq2bDXOKs1dp4IZZduTJKjH8HKFDccGjQ==",
       "dependencies": [
         "esbuild",
         "esbuild-register"
       ]
     },
-    "@prisma/debug@6.6.0-dev.109": {
-      "integrity": "sha512-CQukcfYmrkf5kBQgFJHVhTQLfWBQITl5npLD3rjsJ2PuUHaHE9LjPeRB0S8YRyE3WudV238G3fI48VKLnq3Eyg=="
+    "@prisma/debug@6.6.0-dev.111": {
+      "integrity": "sha512-rsu/BHmftl0alibrZnqJjD+BHus57G40/7PsDWJyM61HAxSTT0hGAHLuEY75wilrPI+twkQAQDMVCVOpdx5Ldw=="
     },
-    "@prisma/engines-version@6.6.0-51.febd1ffa43a7b889647e64817771658dbc24db24": {
-      "integrity": "sha512-ERURCas/tlTytYdaCrtWH7auPAKn9APRIGD6m9xqrmCJx9zcncwg0BCrHvegzxdybodnxECImlseeLU9H6ApyA=="
+    "@prisma/engines-version@6.6.0-52.30389eb8d83fe5c09a7d1d1648e7d5ab7438d1de": {
+      "integrity": "sha512-adHBtZOCvtyqlb1TVQHzz4vA3HGMXjHDy5CXF0KSuTvSXx3k01dQbez7z8PMDfiva0ZZl4INPFbkazCyMkE4fw=="
     },
-    "@prisma/engines@6.6.0-dev.109": {
-      "integrity": "sha512-v/Ewhyx8RXUf/U7WBSEP497aYTLgkkMRJpel8rDedryAtUHOQjzex9N1dOQZGl7DuW8UqgzZOGwYDM8uJ/XvGg==",
+    "@prisma/engines@6.6.0-dev.111": {
+      "integrity": "sha512-PmEc0sPSwkBqiudJVoUbpaxloc9f6NcAZyEH6PsM49xwxfpEADaG5WjGWck2soDn+so8uwcRy4yru8f5murEZQ==",
       "dependencies": [
         "@prisma/debug",
         "@prisma/engines-version",
@@ -123,16 +123,16 @@
         "@prisma/get-platform"
       ]
     },
-    "@prisma/fetch-engine@6.6.0-dev.109": {
-      "integrity": "sha512-TZxAuwZkkucEwGwlwHqfL4V1q41r7nu4nSOJYbEYpUVjQmvCU8l677Ak++iIiFqxn5euU1PdfuYlVd0ONSp/QQ==",
+    "@prisma/fetch-engine@6.6.0-dev.111": {
+      "integrity": "sha512-TOK5qipRknIGcDTLO9DQje++3+jEDDKgNxpfltG9b3tUnuWT0hnrgLhnfCoyVm+2wWCi0DW9DnJ1K999g8TZnA==",
       "dependencies": [
         "@prisma/debug",
         "@prisma/engines-version",
         "@prisma/get-platform"
       ]
     },
-    "@prisma/get-platform@6.6.0-dev.109": {
-      "integrity": "sha512-xSSMq8EevRkSFRAIQUeiIB87iVW3ZEs2q7Crb4z0v0SE1kZHsSAeNAgmTvJQNUm9PMOpjS3wwsUw7Da/AJYUzQ==",
+    "@prisma/get-platform@6.6.0-dev.111": {
+      "integrity": "sha512-AAWMZQQv9Xq5l0b2WEUbwcV/g7kbHLIw+MRtmaIwHNfwQR7wm2wIRpi+1754gDYDhQaOmcOt1DvAY6v4YU6XHQ==",
       "dependencies": [
         "@prisma/debug"
       ]
@@ -192,8 +192,8 @@
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "prisma@6.6.0-dev.109": {
-      "integrity": "sha512-dRWzcuRAUEYZnpKmPW0rmQGBejMig4+/nfQmuQVca5E627SNsspsquAmUJzjbi17r8c91kOWYm/OgsbVnH5cbw==",
+    "prisma@6.6.0-dev.111": {
+      "integrity": "sha512-KfRQvYF6cgrWqoZah6+fdeRxEaFds4E28htlFvA2JFzbzHYlzfazJO7+WjKju9PrqBIiZWM3CZd5vHeCV9Io0A==",
       "dependencies": [
         "@prisma/config",
         "@prisma/engines",
@@ -207,8 +207,8 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.12",
-      "npm:@prisma/client@6.6.0-dev.109",
-      "npm:prisma@6.6.0-dev.109"
+      "npm:@prisma/client@6.6.0-dev.111",
+      "npm:prisma@6.6.0-dev.111"
     ]
   }
 }

--- a/scripts/update-all.sh
+++ b/scripts/update-all.sh
@@ -21,3 +21,14 @@ pnpm -rc --parallel exec "$(pwd)/scripts/update-version.sh $NEW_VERSION"
 pnpm -rc exec "$(pwd)/scripts/update-locks.sh $NEW_VERSION"
 # doing the two separately is important as it also allows us to update the
 # lockfiles in parallel, while also handling monorepo/workspaces correctly
+
+# Update all deno.json and deno.lock files
+find . -name "deno.json" -type f | while read -r deno_json; do
+  deno_dir=$(dirname "$deno_json")
+  repo_root=$(pwd)
+  (
+    cd "$deno_dir" || exit
+    "$repo_root/scripts/update-version.sh" "$NEW_VERSION"
+    "$repo_root/scripts/update-locks.sh" "$NEW_VERSION"
+  )
+done

--- a/scripts/update-locks.sh
+++ b/scripts/update-locks.sh
@@ -12,7 +12,15 @@ corepack enable
 
 # Setting NODE_OPTIONS="" disables yarn-injected shenanigans so we can use package from the root
 PROJECT_PACKAGE_MANAGER=$(NODE_OPTIONS="" node -e "require('@antfu/ni').detect({ autoinstall: false }).then(console.log)")
-IS_GENERATED_CLIENT=$(node -e "const pkg = require('./package.json'); console.log(pkg.name === 'prisma-client')")
+
+IS_GENERATED_CLIENT=$(node -e "
+  try {
+    const pkg = require('./package.json')
+    console.log(pkg.name === 'prisma-client')
+  } catch {
+    console.log(false)
+  }
+")
 
 if [ "$IS_GENERATED_CLIENT" = "true" ]; then
     exit 0


### PR DESCRIPTION
`update-versions.sh` and `update-locks.sh` scripts were not actually run for Deno projects because we ran them for the pnpm workspace packages only. This commit fixes that.