### PR TITLE
fix: set ts targets

### DIFF
--- a/libraries/apollo-server/tsconfig.json
+++ b/libraries/apollo-server/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": "src",
     "lib": ["ES2022", "DOM"],
+    "moduleResolution": "nodenext",
     "esModuleInterop": true,
     "strict": true
   },

--- a/libraries/apollo-server/tsconfig.json
+++ b/libraries/apollo-server/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
+    "target": "ES2022",
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["esnext", "dom"],
+    "lib": ["ES2022", "DOM"],
     "esModuleInterop": true,
     "strict": true
   },

--- a/libraries/apollo-server/tsconfig.json
+++ b/libraries/apollo-server/tsconfig.json
@@ -4,9 +4,10 @@
     "outDir": "dist",
     "rootDir": "src",
     "lib": ["ES2022", "DOM"],
-    "moduleResolution": "nodenext",
+    "module": "NodeNext",
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*"]
 }

--- a/platforms-serverless/azure-functions-linux/tsconfig.json
+++ b/platforms-serverless/azure-functions-linux/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "exclude": [],
-  "include": [
-    "func-placeholder/"
-  ],
+  "include": ["func-placeholder/"],
   "compilerOptions": {
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": "func-placeholder/",
     "strict": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["ES2022", "DOM"],
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/azure-functions-linux/tsconfig.json
+++ b/platforms-serverless/azure-functions-linux/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "func-placeholder/",
     "strict": true,
     "lib": ["ES2022", "DOM"],
-    "moduleResolution": "nodenext",
-    "esModuleInterop": true
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }

--- a/platforms-serverless/azure-functions-linux/tsconfig.json
+++ b/platforms-serverless/azure-functions-linux/tsconfig.json
@@ -7,6 +7,7 @@
     "outDir": "func-placeholder/",
     "strict": true,
     "lib": ["ES2022", "DOM"],
+    "moduleResolution": "nodenext",
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/azure-functions-linux/tsconfig.json
+++ b/platforms-serverless/azure-functions-linux/tsconfig.json
@@ -8,7 +8,6 @@
     "strict": true,
     "lib": ["ES2022", "DOM"],
     "module": "NodeNext",
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "esModuleInterop": true
   }
 }

--- a/platforms-serverless/gcp-functions/tsconfig.json
+++ b/platforms-serverless/gcp-functions/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": ".",
     "strict": true,
     "lib": ["ES2022", "DOM"],
+    "moduleResolution": "nodenext",
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/gcp-functions/tsconfig.json
+++ b/platforms-serverless/gcp-functions/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": ".",
     "strict": true,
     "lib": ["ES2022", "DOM"],
-    "moduleResolution": "nodenext",
-    "esModuleInterop": true
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }

--- a/platforms-serverless/gcp-functions/tsconfig.json
+++ b/platforms-serverless/gcp-functions/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "exclude": [],
   "compilerOptions": {
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": ".",
     "strict": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["ES2022", "DOM"],
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/gcp-functions/tsconfig.json
+++ b/platforms-serverless/gcp-functions/tsconfig.json
@@ -7,7 +7,6 @@
     "strict": true,
     "lib": ["ES2022", "DOM"],
     "module": "NodeNext",
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "esModuleInterop": true
   }
 }

--- a/platforms-serverless/lambda-node-20/tsconfig.json
+++ b/platforms-serverless/lambda-node-20/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": ".",
     "strict": true,
     "lib": ["ES2022", "DOM"],
+    "moduleResolution": "nodenext",
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/lambda-node-20/tsconfig.json
+++ b/platforms-serverless/lambda-node-20/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": ".",
     "strict": true,
     "lib": ["ES2022", "DOM"],
-    "moduleResolution": "nodenext",
-    "esModuleInterop": true
+    "module": "NodeNext",
+    "esModuleInterop": true,
+    "skipLibCheck": true
   }
 }

--- a/platforms-serverless/lambda-node-20/tsconfig.json
+++ b/platforms-serverless/lambda-node-20/tsconfig.json
@@ -1,10 +1,11 @@
 {
   "exclude": [],
   "compilerOptions": {
+    "target": "ES2022",
     "sourceMap": true,
     "outDir": ".",
     "strict": true,
-    "lib": ["esnext", "dom"],
+    "lib": ["ES2022", "DOM"],
     "esModuleInterop": true
   }
 }

--- a/platforms-serverless/lambda-node-20/tsconfig.json
+++ b/platforms-serverless/lambda-node-20/tsconfig.json
@@ -7,7 +7,6 @@
     "strict": true,
     "lib": ["ES2022", "DOM"],
     "module": "NodeNext",
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
seems we need to set a recent ES target because prisma now uses private identifiers, also needed to add skipLibCheck because some libraries have imports incompatible with node16: https://github.com/benjamn/wryware/issues/646