### PR TITLE
fix: bump node

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -424,7 +424,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
           cache-dependency-path: ${{ github.job }}/${{ matrix.combo }}/pnpm-lock.yaml
 


### PR DESCRIPTION
Fixes [driver-adapters-wasm (pg-cf-hyperdrive, wasm, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/15710927504/job/44268541340#logs)