### PR TITLE
fix(engine-types): remove `PRISMA_CLI_QUERY_ENGINE_TYPE` tests

### DIFF
--- a/engines/engine-types/all.test.ts
+++ b/engines/engine-types/all.test.ts
@@ -1,27 +1,13 @@
-import {
-  DEFAULT_CLIENT_ENGINE_TYPE,
-  DEFAULT_CLI_QUERY_ENGINE_TYPE,
-  EngineType,
-} from './constants'
+import { DEFAULT_CLIENT_ENGINE_TYPE, EngineType } from './constants'
 import { getCustomBinaryPath, getCustomLibraryPath, runTest } from './utils'
 
-describe(`Engine Types - default(CLI=${DEFAULT_CLI_QUERY_ENGINE_TYPE} Client=${DEFAULT_CLIENT_ENGINE_TYPE})`, () => {
+describe(`Engine Types - default(Client=${DEFAULT_CLIENT_ENGINE_TYPE})`, () => {
   // Test Default
   runTest({})
 
   // ENV Overrides
   runTest({
     env: {
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Binary,
-    },
-  })
-  runTest({
-    env: {
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Library,
-    },
-  })
-  runTest({
-    env: {
       PRISMA_QUERY_ENGINE_LIBRARY: getCustomLibraryPath(),
     },
   })
@@ -32,7 +18,6 @@ describe(`Engine Types - default(CLI=${DEFAULT_CLI_QUERY_ENGINE_TYPE} Client=${D
   })
   runTest({
     env: {
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Binary,
       PRISMA_QUERY_ENGINE_LIBRARY: getCustomLibraryPath(),
       PRISMA_QUERY_ENGINE_BINARY: getCustomBinaryPath(),
     },
@@ -45,18 +30,6 @@ describe(`Engine Types - default(CLI=${DEFAULT_CLI_QUERY_ENGINE_TYPE} Client=${D
   runTest({
     env: {
       PRISMA_CLIENT_ENGINE_TYPE: EngineType.Library,
-    },
-  })
-  runTest({
-    env: {
-      PRISMA_CLIENT_ENGINE_TYPE: EngineType.Binary,
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Binary,
-    },
-  })
-  runTest({
-    env: {
-      PRISMA_CLIENT_ENGINE_TYPE: EngineType.Library,
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Library,
     },
   })
   // Schema

--- a/engines/engine-types/constants.ts
+++ b/engines/engine-types/constants.ts
@@ -9,7 +9,6 @@ export interface TestOptions {
     binaryTargets?: string[]
   }
   env?: {
-    PRISMA_CLI_QUERY_ENGINE_TYPE?: EngineType | undefined
     PRISMA_CLIENT_ENGINE_TYPE?: EngineType | undefined
     PRISMA_QUERY_ENGINE_LIBRARY?: string | undefined
     PRISMA_QUERY_ENGINE_BINARY?: string | undefined
@@ -19,19 +18,14 @@ export interface TestOptions {
 }
 export interface Expected {
   clientEngineType: EngineType
-  cliEngineType: EngineType
 }
 
 export const ENV_VARS = {
   // Overrides the query engine used in the generated client
   PRISMA_CLIENT_ENGINE_TYPE: 'PRISMA_CLIENT_ENGINE_TYPE',
-  // Overrides the query engine used in the CLI
-  PRISMA_CLI_QUERY_ENGINE_TYPE: 'PRISMA_CLI_QUERY_ENGINE_TYPE',
   // For Overriding Query Engine Library Path
   PRISMA_QUERY_ENGINE_LIBRARY: 'PRISMA_QUERY_ENGINE_LIBRARY',
   // For Overriding Query Engine Binary Path
   PRISMA_QUERY_ENGINE_BINARY: 'PRISMA_QUERY_ENGINE_BINARY',
 }
-export const DEFAULT_CLI_QUERY_ENGINE_TYPE = EngineType.Library
 export const DEFAULT_CLIENT_ENGINE_TYPE = EngineType.Library
-

--- a/engines/engine-types/custom.test.ts
+++ b/engines/engine-types/custom.test.ts
@@ -1,39 +1,27 @@
 import { EngineType } from './constants'
-import {
-  getCustomBinaryPath,
-  getCustomLibraryPath,
-  runTest,
-} from './utils'
+import { getCustomBinaryPath, getCustomLibraryPath, runTest } from './utils'
 
 function buildTests() {
-  const engineTypes = [
-    EngineType.Binary,
-    EngineType.Library,
-    undefined,
-  ] as const
+  const engineTypes = [EngineType.Binary, EngineType.Library, undefined] as const
   const PRISMA_CLIENT_ENGINE_TYPE = engineTypes
-  const PRISMA_CLI_QUERY_ENGINE_TYPE = engineTypes
   const PRISMA_QUERY_ENGINE_LIBRARY = [undefined, getCustomLibraryPath()]
   const PRISMA_QUERY_ENGINE_BINARY = [undefined, getCustomBinaryPath()]
 
   engineTypes.forEach((engineType) => {
     PRISMA_CLIENT_ENGINE_TYPE.forEach((clientEngineType) => {
-      PRISMA_CLI_QUERY_ENGINE_TYPE.forEach((cliQueryEngineType) => {
-        PRISMA_QUERY_ENGINE_LIBRARY.forEach((customQELibrary) => {
-          PRISMA_QUERY_ENGINE_BINARY.forEach((customQEBinary) => {
-            const options = {
-              env: {
-                PRISMA_CLI_QUERY_ENGINE_TYPE: cliQueryEngineType,
-                PRISMA_CLIENT_ENGINE_TYPE: clientEngineType,
-                PRISMA_QUERY_ENGINE_LIBRARY: customQELibrary,
-                PRISMA_QUERY_ENGINE_BINARY: customQEBinary,
-              },
-              schema: {
-                engineType: engineType,
-              }
-            }
-            runTest(options)
-          })
+      PRISMA_QUERY_ENGINE_LIBRARY.forEach((customQELibrary) => {
+        PRISMA_QUERY_ENGINE_BINARY.forEach((customQEBinary) => {
+          const options = {
+            env: {
+              PRISMA_CLIENT_ENGINE_TYPE: clientEngineType,
+              PRISMA_QUERY_ENGINE_LIBRARY: customQELibrary,
+              PRISMA_QUERY_ENGINE_BINARY: customQEBinary,
+            },
+            schema: {
+              engineType: engineType,
+            },
+          }
+          runTest(options)
         })
       })
     })

--- a/engines/engine-types/utils.ts
+++ b/engines/engine-types/utils.ts
@@ -2,13 +2,7 @@ import execa from 'execa'
 import fs from 'fs-extra'
 import os from 'os'
 import path from 'path'
-import {
-  DEFAULT_CLIENT_ENGINE_TYPE,
-  DEFAULT_CLI_QUERY_ENGINE_TYPE,
-  EngineType,
-  Expected,
-  TestOptions,
-} from './constants'
+import { DEFAULT_CLIENT_ENGINE_TYPE, EngineType, Expected, TestOptions } from './constants'
 
 const defaultExecaOptions = {
   preferLocal: true,
@@ -32,9 +26,7 @@ datasource db {
   const previewFeaturesStr = options?.previewFeatures
     ? `previewFeatures = ${options.previewFeatures.map((p) => `["${p}"]`)}`
     : ''
-  const clientEngineType = options?.engineType
-    ? `engineType = "${options.engineType}"`
-    : ''
+  const clientEngineType = options?.engineType ? `engineType = "${options.engineType}"` : ''
   const binaryTargetsStr = options?.binaryTargets
     ? `binaryTargets = ${options.binaryTargets.map((p) => `["${p}"]`)}`
     : ''
@@ -67,33 +59,38 @@ model Post {
 }
 
 function getClientPackageDir(projectDir: string) {
-  return path.dirname(require.resolve('@prisma/client/package.json', {
-    paths: [projectDir],
-  }))
+  return path.dirname(
+    require.resolve('@prisma/client/package.json', {
+      paths: [projectDir],
+    }),
+  )
 }
 
 function getCliPackageDir(projectDir: string) {
-  return path.dirname(require.resolve('prisma/package.json', {
-    paths: [projectDir],
-  }))
+  return path.dirname(
+    require.resolve('prisma/package.json', {
+      paths: [projectDir],
+    }),
+  )
 }
 
 function getEnginesPackageDir(projectDir: string) {
-  return path.dirname(require.resolve('@prisma/engines/package.json', {
-    paths: [getCliPackageDir(projectDir)]
-  }))
+  return path.dirname(
+    require.resolve('@prisma/engines/package.json', {
+      paths: [getCliPackageDir(projectDir)],
+    }),
+  )
 }
 
 function getGeneratedClientDir(projectDir: string) {
-  return path.dirname(require.resolve('.prisma/client/package.json', {
-    paths: [getClientPackageDir(projectDir)]
-  }))
+  return path.dirname(
+    require.resolve('.prisma/client/package.json', {
+      paths: [getClientPackageDir(projectDir)],
+    }),
+  )
 }
 
-async function generate(
-  projectDir: string,
-  env?: Record<string, string | undefined>,
-) {
+async function generate(projectDir: string, env?: Record<string, string | undefined>) {
   await execa('pnpm', ['prisma', 'generate'], {
     ...defaultExecaOptions,
     env,
@@ -105,10 +102,7 @@ async function removePrismaCache() {
   fs.rmdirSync(path.join(os.homedir(), '.cache/prisma'), { recursive: true })
 }
 
-export async function install(
-  projectDir: string,
-  env?: Record<string, string | undefined>,
-) {
+export async function install(projectDir: string, env?: Record<string, string | undefined>) {
   await execa('pnpm', ['install', '--reporter', 'silent'], {
     ...defaultExecaOptions,
     env,
@@ -116,10 +110,7 @@ export async function install(
   })
 }
 
-export async function version(
-  projectDir: string,
-  env?: Record<string, string | undefined>,
-) {
+export async function version(projectDir: string, env?: Record<string, string | undefined>) {
   const result = await execa('pnpm', ['prisma', '-v'], {
     ...defaultExecaOptions,
     stdio: 'pipe',
@@ -189,9 +180,7 @@ function sanitizeVersionSnapshot(projectDir: string, str: string): string {
       const test = line.split(':')
       const location = test[1].match(/\(([^)]+)\)/)
       const relativeDir = path.relative(projectDir, process.cwd()) + '/'
-      return `${test[0]} : placeholder ${
-        location ? location[0].replace(relativeDir, '') : ''
-      }`
+      return `${test[0]} : placeholder ${location ? location[0].replace(relativeDir, '') : ''}`
     })
     .join('\n')
 }
@@ -202,39 +191,20 @@ async function setupTmpProject(projectDir: string) {
     fs.copy('./package.json', path.join(projectDir, './package.json')),
     fs.copy('./tsconfig.json', path.join(projectDir, './tsconfig.json')),
     fs.copy('./prisma/dev.db', path.join(projectDir, './prisma/dev.db')),
-    fs.copy(
-      './test-generated-client.js',
-      path.join(projectDir, './test-generated-client.js'),
-    ),
+    fs.copy('./test-generated-client.js', path.join(projectDir, './test-generated-client.js')),
   ]
   await Promise.all(wait)
 }
 function generateTestName(options: TestOptions, expected: Expected) {
-  const expectedStr = `expected(CLI=${expected.cliEngineType}, CLIENT=${expected.clientEngineType})`
+  const expectedStr = `expected(CLIENT=${expected.clientEngineType})`
   const envOverridesStr = options?.env
-    ? `env(PRISMA_CLIENT_ENGINE_TYPE=${
-        options?.env?.PRISMA_CLIENT_ENGINE_TYPE
-      }, PRISMA_CLI_QUERY_ENGINE_TYPE=${
-        options?.env?.PRISMA_CLI_QUERY_ENGINE_TYPE
-      } ${
-        options?.env?.PRISMA_QUERY_ENGINE_LIBRARY
-          ? 'PRISMA_QUERY_ENGINE_LIBRARY '
-          : ''
-      }${
-        options?.env?.PRISMA_QUERY_ENGINE_BINARY
-          ? 'PRISMA_QUERY_ENGINE_BINARY'
-          : ''
+    ? `env(PRISMA_CLIENT_ENGINE_TYPE=${options?.env?.PRISMA_CLIENT_ENGINE_TYPE}, ${options?.env?.PRISMA_QUERY_ENGINE_LIBRARY ? 'PRISMA_QUERY_ENGINE_LIBRARY ' : ''}${
+        options?.env?.PRISMA_QUERY_ENGINE_BINARY ? 'PRISMA_QUERY_ENGINE_BINARY' : ''
       })`
     : ''
   const schemaStr = options?.schema
-    ? ` schema(${
-        options?.schema?.engineType
-          ? `engineType=${options?.schema?.engineType} `
-          : ''
-      }${
-        options?.schema?.previewFeatures
-          ? `previewFeatures=[${options?.schema?.previewFeatures.join(',')}]`
-          : ''
+    ? ` schema(${options?.schema?.engineType ? `engineType=${options?.schema?.engineType} ` : ''}${
+        options?.schema?.previewFeatures ? `previewFeatures=[${options?.schema?.previewFeatures.join(',')}]` : ''
       })`
     : ``
   return [expectedStr, envOverridesStr, schemaStr].join(' ')
@@ -244,70 +214,24 @@ function generateTestName(options: TestOptions, expected: Expected) {
  * Checks the version output for the correct engine and if `PRISMA_QUERY_ENGINE_BINARY` or `PRISMA_QUERY_ENGINE_LIBRARY`
  * are correctly used
  */
-async function checkVersionOutput(
-  projectDir: string,
-  options: TestOptions,
-  expected: Expected,
-) {
+async function checkVersionOutput(projectDir: string, options: TestOptions, expected: Expected) {
   const expectedQueryEngineRE =
-    expected.cliEngineType === EngineType.Binary
+    expected.clientEngineType === EngineType.Binary
       ? new RegExp(/Query Engine \(Binary\)/)
       : new RegExp(/Query Engine \(Node-API\)/)
 
   const versionOutput = await version(projectDir, options.env)
   const hasCorrectEngine = expectedQueryEngineRE.test(versionOutput)
   expect(hasCorrectEngine).toBe(true)
-  if (
-    options.env?.PRISMA_QUERY_ENGINE_BINARY &&
-    expected.cliEngineType === EngineType.Binary
-  ) {
+  if (options.env?.PRISMA_QUERY_ENGINE_BINARY && expected.clientEngineType === EngineType.Binary) {
     expect(versionOutput).toContain('resolved by PRISMA_QUERY_ENGINE_BINARY')
   }
-  if (
-    options.env?.PRISMA_QUERY_ENGINE_LIBRARY &&
-    expected.cliEngineType === EngineType.Library
-  ) {
+  if (options.env?.PRISMA_QUERY_ENGINE_LIBRARY && expected.clientEngineType === EngineType.Library) {
     expect(versionOutput).toContain('resolved by PRISMA_QUERY_ENGINE_LIBRARY')
   }
 }
 
-function checkCLIForExpectedEngine(
-  projectDir: string,
-  options: TestOptions,
-  expected: Expected,
-) {
-  const enginesDir = getEnginesPackageDir(projectDir)
-  const enginesFiles = fs.readdirSync(enginesDir)
-  if (expected.cliEngineType === EngineType.Binary) {
-    // Binary
-    const binaryName = getOSBinaryName()
-    const hasQEBinary = enginesFiles.includes(binaryName)
-    if (options.env && options.env?.PRISMA_QUERY_ENGINE_BINARY) {
-      // If a custom path is specified for the QE then it should not be present
-      expect(hasQEBinary).toBe(false)
-    } else {
-      // If no custom path is specified then the QE Binary should be present
-      expect(hasQEBinary).toBe(true)
-    }
-  } else {
-    // Library
-    const libraryName = getOSLibraryName()
-    const hasQELibrary = enginesFiles.includes(libraryName)
-    if (options.env && options.env?.PRISMA_QUERY_ENGINE_LIBRARY) {
-      // If a custom path is specified for the QE Library then it should not be present
-      // expect(hasQELibrary).toBe(false) // TODO this does not work with npm & pnpm
-    } else {
-      // If no custom path is specified then the QE Library should be present
-      expect(hasQELibrary).toBe(true)
-    }
-  }
-}
-
-function checkClientForExpectedEngine(
-  projectDir: string,
-  options: TestOptions,
-  expected: Expected,
-) {
+function checkClientForExpectedEngine(projectDir: string, options: TestOptions, expected: Expected) {
   const generatedClientDir = getGeneratedClientDir(projectDir)
   const clientFiles = fs.readdirSync(generatedClientDir)
   if (expected.clientEngineType === EngineType.Binary) {
@@ -329,83 +253,73 @@ export async function runTest(options: TestOptions) {
   const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-'))
   const expected = getExpectedEngineTypes(options)
   const testName = generateTestName(options, expected)
-  return test(testName, async () => {
-    console.log(`Project DIR: ${projectDir}`)
-    // await removePrismaCache()
-    await setupTmpProject(projectDir)
-    buildSchemaFile(projectDir, options.schema)
+  return test(
+    testName,
+    async () => {
+      console.log(`Project DIR: ${projectDir}`)
+      // await removePrismaCache()
+      await setupTmpProject(projectDir)
+      buildSchemaFile(projectDir, options.schema)
 
-    // pnpm install
-    await install(projectDir, options.env)
-    // snapshotDirectory(projectDir, './node_modules/@prisma/engines')
-    // snapshotDirectory(projectDir, './node_modules/prisma')
+      // pnpm install
+      await install(projectDir, options.env)
+      // snapshotDirectory(projectDir, './node_modules/@prisma/engines')
+      // snapshotDirectory(projectDir, './node_modules/prisma')
 
-    await checkVersionOutput(projectDir, options, expected)
+      await checkVersionOutput(projectDir, options, expected)
 
-    // Check CLI Engine Files
-    // expect(sanitizeVersionSnapshot(projectDir, versionOutput)).toMatchSnapshot(
-    //   'version output @ 0 - env',
-    // )
-    checkCLIForExpectedEngine(projectDir, options, expected)
+      // prisma generate
+      await generate(projectDir, options.env)
+      // snapshotDirectory(projectDir, './node_modules/.prisma/client', '0 - env')
 
-    // prisma generate
-    await generate(projectDir, options.env)
-    // snapshotDirectory(projectDir, './node_modules/.prisma/client', '0 - env')
+      // Check Generated Client Engine
+      checkClientForExpectedEngine(projectDir, options, expected)
 
-    // Check Generated Client Engine
-    checkClientForExpectedEngine(projectDir, options, expected)
+      // Overwrite env to simulate deployment with different settings
+      if (options.env_on_deploy) {
+        options.env = options.env_on_deploy
+      }
 
-    // Overwrite env to simulate deployment with different settings
-    if (options.env_on_deploy) {
-      options.env = options.env_on_deploy
-    }
+      await testGeneratedClient(projectDir, options.env, expected)
 
-    await testGeneratedClient(projectDir, options.env, expected)
-
-    // Additional snapshots if env changed after generate
-    if (options.env_on_deploy) {
-      const expectedPostDeploy = getExpectedEngineTypes(options)
-      await checkVersionOutput(projectDir, options, expectedPostDeploy)
-    }
-  }, 300_000)
+      // Additional snapshots if env changed after generate
+      if (options.env_on_deploy) {
+        const expectedPostDeploy = getExpectedEngineTypes(options)
+        await checkVersionOutput(projectDir, options, expectedPostDeploy)
+      }
+    },
+    300_000,
+  )
 }
 export function getOSBinaryName() {
   return os.type() == 'Windows_NT'
     ? 'query-engine-windows.exe'
     : os.type() == 'Darwin'
-    ? 'query-engine-darwin'
-    : 'query-engine-debian-openssl-1.1.x'
+      ? os.arch() === 'arm64'
+        ? 'query-engine-darwin-arm64'
+        : 'query-engine-darwin'
+      : 'query-engine-debian-openssl-1.1.x'
 }
 
 export function getOSLibraryName() {
   return os.type() == 'Windows_NT'
     ? 'query_engine-windows.dll.node'
     : os.type() == 'Darwin'
-    ? 'libquery_engine-darwin.dylib.node'
-    : 'libquery_engine-debian-openssl-1.1.x.so.node'
+      ? os.arch() === 'arm64'
+        ? 'libquery_engine-darwin-arm64.dylib.node'
+        : 'libquery_engine-darwin.dylib.node'
+      : 'libquery_engine-debian-openssl-1.1.x.so.node'
 }
 export function getCustomBinaryPath() {
   // Using absolute path because of https://github.com/prisma/prisma/issues/7779
-  let engine = path.resolve(
-    '.',
-    'custom-engines',
-    'binary',
-    os.type(),
-    getOSBinaryName(),
-  )
+  let engine = path.resolve('.', 'custom-engines', 'binary', os.type(), getOSBinaryName())
   console.log('binary', { engine })
   return engine
 }
 
 export function getCustomLibraryPath() {
   // Using absolute path because of https://github.com/prisma/prisma/issues/7779
-  let engine = path.resolve(
-    '.',
-    'custom-engines',
-    'library',
-    os.type(),
-    getOSLibraryName(),
-  )
+  let engine = path.resolve('.', 'custom-engines', 'library', os.type(), getOSLibraryName())
   console.log('library', { engine })
   return engine
 }
@@ -415,7 +329,7 @@ export async function getCustomEngines() {
   if (!fs.existsSync(binaryFolder)) {
     fs.mkdirpSync(binaryFolder)
     const env = {
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Binary,
+      PRISMA_CLIENT_ENGINE_TYPE: EngineType.Binary,
     }
     await install(process.cwd(), env)
     await version(process.cwd(), env)
@@ -426,7 +340,7 @@ export async function getCustomEngines() {
   const libraryFolder = './custom-engines/library/' + os.type()
   if (!fs.existsSync(libraryFolder)) {
     const env = {
-      PRISMA_CLI_QUERY_ENGINE_TYPE: EngineType.Library,
+      PRISMA_CLIENT_ENGINE_TYPE: EngineType.Library,
     }
 
     await install(process.cwd(), env)
@@ -437,7 +351,6 @@ export async function getCustomEngines() {
 export function getExpectedEngineTypes(options: TestOptions): Expected {
   return {
     clientEngineType: getExpectedClientEngineType(options),
-    cliEngineType: getExpectedCLIEngineType(options),
   }
 }
 export function getExpectedClientEngineType(options: TestOptions) {
@@ -447,18 +360,9 @@ export function getExpectedClientEngineType(options: TestOptions) {
   if (options.schema?.engineType) {
     return options.schema?.engineType
   }
-  if (
-    options.schema?.previewFeatures &&
-    options.schema?.previewFeatures.includes('nApi')
-  ) {
+  if (options.schema?.previewFeatures && options.schema?.previewFeatures.includes('nApi')) {
     return EngineType.Library
   }
 
   return DEFAULT_CLIENT_ENGINE_TYPE
-}
-export function getExpectedCLIEngineType(options: TestOptions) {
-  if (options?.env?.PRISMA_CLI_QUERY_ENGINE_TYPE) {
-    return options?.env?.PRISMA_CLI_QUERY_ENGINE_TYPE
-  }
-  return DEFAULT_CLI_QUERY_ENGINE_TYPE
 }


### PR DESCRIPTION
Tests for `PRISMA_CLI_QUERY_ENGINE_TYPE` with `prisma generate` have been failing since the changes related to not downloading the query engine when using query compiler were made.

We don't actually care about these anymore because Generate has not been using the query engine for a long time, ever since we introduced the WebAssembly module containing `getConfig` and `getDmmf`.

Only the schema engine is used by the CLI (by Migrate, and also by Generate when using TypedSQL). `PRISMA_CLI_QUERY_ENGINE_TYPE` does not apply to the schema engine because there's no Node-API variant of it.

Closes: https://linear.app/prisma-company/issue/ORM-1150/fix-engine-types-tests