### PR TITLE
fix: exclude prisma cli from serverless bundling

### DIFF
--- a/platforms-serverless/serverless-framework-lambda/serverless.yml
+++ b/platforms-serverless/serverless-framework-lambda/serverless.yml
@@ -23,3 +23,4 @@ package:
   - '!node_modules/.prisma/client/libquery_engine-*'
   - 'node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node'
   - 'node_modules/.prisma/client/query-engine-rhel-openssl-3.0.x'
+  - '!node_modules/prisma/**'


### PR DESCRIPTION
We packaged the prisma cli into the serverless bundle. But this got all way too big now with all the additional wasm files.