### PR TITLE
fix(accelerate/nodejs-tracing): remove middleware instrumentation

### DIFF
--- a/accelerate/nodejs-tracing/index.test.ts
+++ b/accelerate/nodejs-tracing/index.test.ts
@@ -33,7 +33,7 @@ beforeAll(() => {
   basicTracerProvider.register()
 
   registerInstrumentations({
-    instrumentations: [new PrismaInstrumentation({ middleware: true })],
+    instrumentations: [new PrismaInstrumentation()],
   })
 })
 


### PR DESCRIPTION
Fixes a TypeScript error:

```
      index.test.ts:36:52 - error TS2353: Object literal may only specify known properties, and 'middleware' does not exist in type 'Config'.
  
      36     instrumentations: [new PrismaInstrumentation({ middleware: true })],
                                                            ~~~~~~~~~~
```