### PR TITLE
fix: restore deno.lock files

### DIFF
--- a/accelerate/deno/deno.lock
+++ b/accelerate/deno/deno.lock
@@ -1,15 +1,15 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@std/assert@^1.0.12": "1.0.13",
+    "jsr:@std/assert@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.6": "1.0.6",
-    "npm:@prisma/client@7.1.0-dev.10": "7.1.0-dev.10_prisma@7.1.0-dev.10",
-    "npm:@prisma/extension-accelerate@1.2.2": "1.2.2_@prisma+client@7.1.0-dev.10__prisma@7.1.0-dev.10_prisma@7.1.0-dev.10",
-    "npm:prisma@7.1.0-dev.10": "7.1.0-dev.10"
+    "npm:@prisma/client@7.1.0-dev.15": "7.1.0-dev.15_prisma@7.1.0-dev.15",
+    "npm:@prisma/extension-accelerate@1.2.2": "1.2.2_@prisma+client@7.1.0-dev.15__prisma@7.1.0-dev.15_prisma@7.1.0-dev.15",
+    "npm:prisma@7.1.0-dev.15": "7.1.0-dev.15"
   },
   "jsr": {
-    "@std/assert@1.0.13": {
-      "integrity": "ae0d31e41919b12c656c742b22522c32fb26ed0cba32975cb0de2a273cb68b29",
+    "@std/assert@1.0.12": {
+      "integrity": "08009f0926dda9cbd8bef3a35d3b6a4b964b0ab5c3e140a4e0351fbf34af5b9a",
       "dependencies": [
         "jsr:@std/internal"
       ]
@@ -69,11 +69,11 @@
         "lilconfig"
       ]
     },
-    "@prisma/client-runtime-utils@7.1.0-dev.10": {
-      "integrity": "sha512-V98cgyAwlMBK92JG+b2YcEwlF50lfigHyDkS433S7cYxahVZPdtccOxF+k0CW/rx/e7/BtjG4XcJ0wvbDN3D0g=="
+    "@prisma/client-runtime-utils@7.1.0-dev.15": {
+      "integrity": "sha512-H2Dmnn3pGrWpw7O56gIB3d9zTSXu9EZ50DljNXt0r4XNe//eM4kOEdipak6FGnxjPa30NXFOQEwaRXkhVRJHSA=="
     },
-    "@prisma/client@7.1.0-dev.10_prisma@7.1.0-dev.10": {
-      "integrity": "sha512-qGCgxahK3KdfceBIl4oBAQFBhAU618qq+XMnef7z8KEQ96+KDDr0Q//V1IU3Vc7XlN0EIcV7azQWkCHbRnIl0w==",
+    "@prisma/client@7.1.0-dev.15_prisma@7.1.0-dev.15": {
+      "integrity": "sha512-6WNRbSwiI/WCSfWSvXHIpwdHOE76Py6Rzdm69vDgXA7IWy0p0vpvEar3gvozdjkaorBf+t9nMVN65qO2wWbxwg==",
       "dependencies": [
         "@prisma/client-runtime-utils",
         "prisma"
@@ -82,8 +82,8 @@
         "prisma"
       ]
     },
-    "@prisma/config@7.1.0-dev.10": {
-      "integrity": "sha512-Wjvudgv6t1aglbNaP1ESwLlpRcrcQ8V//kcg56qQaGcK5c5sY3ievny5LRLYBd5P30QUoAbIZ7UwJIgEjt254w==",
+    "@prisma/config@7.1.0-dev.15": {
+      "integrity": "sha512-d0DBR83jafQwwFBSalYIf9W6WTpTYhIdePjU5HA/VX22vmc0aGFuIhS+6JNjaTNvV9XedmVLSlkjboNMVlbvIw==",
       "dependencies": [
         "c12",
         "deepmerge-ts",
@@ -94,8 +94,8 @@
     "@prisma/debug@6.8.2": {
       "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg=="
     },
-    "@prisma/debug@7.1.0-dev.10": {
-      "integrity": "sha512-mdzVT3ttKLkmXf0bX+honyCdDbZKKdKamTazKwRO77R/kItk/0jmBBCjq6aBhTisDqkhg0+CxsdcchYy3Fsb3A=="
+    "@prisma/debug@7.1.0-dev.15": {
+      "integrity": "sha512-9gVVHLJTxSQ8l8iWL0/jRvtmIQqLKhfUsuFC/e4EXBxZKkxLdbNqgXSuLOwvO1Fv3m7W2QMGzlGg6QGpw2z/jA=="
     },
     "@prisma/dev@0.13.0_@electric-sql+pglite@0.3.2_hono@4.7.10": {
       "integrity": "sha512-QMmF6zFeUF78yv1HYbHvod83AQnl7u6NtKyDhTRZOJup3h1icWs8R7RUVxBJZvM2tBXNAMpLQYYM/8kPlOPegA==",
@@ -119,31 +119,31 @@
         "zeptomatch"
       ]
     },
-    "@prisma/engines-version@7.1.0-4.671452b04ff2b1a300f34311d53ac29cc925e1a7": {
-      "integrity": "sha512-Q2mjAZTZ+98Ym3a1T2Fm+RlBW2v7MPIMa4QzDQNmFXHDZJB3Uz70XrP9zZ+31C+urp4AVicjzGmwpYX5y3utSQ=="
+    "@prisma/engines-version@7.1.0-3.d9cee0d5892b6ac19222fb0ef2384cc3d5efd043": {
+      "integrity": "sha512-gDWKrBS1Urw6gX5lzKvzu3md3zVqRvZLFExzfEGBVy9Y0vKwd4tQHSv3rcVwVK1WUaNjIhLTIHscgMkULi1soQ=="
     },
-    "@prisma/engines@7.1.0-dev.16": {
-      "integrity": "sha512-HkkitesaWFynZf+RqHeDnjwY40BEOrd12nt65o7JcCKjMnxGIuylSeLc9Q5/kNltzNN4k+SlOI0p7l1z0RmpMg==",
+    "@prisma/engines@7.1.0-dev.15": {
+      "integrity": "sha512-+hMy8d9FuRWkYX3fyy6huQ0E5n9da1uftoYXtG8ZUWM+T+8D0kMf7lUBxCiTTmxxrR9ZLktWWc+vrrQbi/o39w==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16",
+        "@prisma/debug@7.1.0-dev.15",
         "@prisma/engines-version",
         "@prisma/fetch-engine",
-        "@prisma/get-platform@7.1.0-dev.16"
+        "@prisma/get-platform@7.1.0-dev.15"
       ],
       "scripts": true
     },
-    "@prisma/extension-accelerate@1.2.2_@prisma+client@7.1.0-dev.10__prisma@7.1.0-dev.10_prisma@7.1.0-dev.10": {
+    "@prisma/extension-accelerate@1.2.2_@prisma+client@7.1.0-dev.15__prisma@7.1.0-dev.15_prisma@7.1.0-dev.15": {
       "integrity": "sha512-LOlfkG6If+o8PFRzLzp26ackP/d+j2HrkTJaxuV/Wd+sdAHz/AkmzEDGbo2UpHFpxEM9hWMBe3ScSwUKYUDOXg==",
       "dependencies": [
         "@prisma/client"
       ]
     },
-    "@prisma/fetch-engine@7.1.0-dev.10": {
-      "integrity": "sha512-UIQU+ZLmDyMsrpWwqK88PxcSx58tE08pz15/QVRNK0CkMNfNIRFh1a1+Kf05r1ywXa4JINVHqgit2KN8uTw7kQ==",
+    "@prisma/fetch-engine@7.1.0-dev.15": {
+      "integrity": "sha512-dfEr/yC19U8WARZYl0MLG8wjs4NWGmWgVTcNZv+MCBjoNUkJZd7NLgxAdyXAdExoRvIj5m1jFdWdiMivVfvv2g==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16",
+        "@prisma/debug@7.1.0-dev.15",
         "@prisma/engines-version",
-        "@prisma/get-platform@7.1.0-dev.16"
+        "@prisma/get-platform@7.1.0-dev.15"
       ]
     },
     "@prisma/get-platform@6.8.2": {
@@ -152,17 +152,17 @@
         "@prisma/debug@6.8.2"
       ]
     },
-    "@prisma/get-platform@7.1.0-dev.16": {
-      "integrity": "sha512-0vvBkSSj5ikC6oTXF8PGUSfzZ9dEJX+VSS65Y5QVtp5z5qsxR2dGm/bCo91Qwid2+F3NUYCSbGt07MaAB3L+rg==",
+    "@prisma/get-platform@7.1.0-dev.15": {
+      "integrity": "sha512-GANk5MgyF71LyD/vbRlCOuCm2OG56JVrYfFi6/dMcuw2XCFdN+/wSlqSKJRHValh5/Azg4so7ZMfFqRJIPU4Lg==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16"
+        "@prisma/debug@7.1.0-dev.15"
       ]
     },
     "@prisma/query-plan-executor@6.18.0": {
       "integrity": "sha512-jZ8cfzFgL0jReE1R10gT8JLHtQxjWYLiQ//wHmVYZ2rVkFHoh0DT8IXsxcKcFlfKN7ak7k6j0XMNn2xVNyr5cA=="
     },
-    "@prisma/studio-core-licensed@0.8.1_@types+react@19.2.7_react@19.2.0_react-dom@19.2.0__react@19.2.0": {
-      "integrity": "sha512-9aMnKEvZvE85whW9w3TYACRDasnAEz/DlCnR8Nbh+f9+z1k8W5JVGHfO/UVBNQbSjT/imXsC8zFPVPxPuF4WFw==",
+    "@prisma/studio-core@0.8.2_@types+react@19.2.5_react@19.2.0_react-dom@19.2.0__react@19.2.0": {
+      "integrity": "sha512-/iAEWEUpTja+7gVMu1LtR2pPlvDmveAwMHdTWbDeGlT7yiv0ZTCPpmeAGdq/Y9aJ9Zj1cEGBXGRbmmNPj022PQ==",
       "dependencies": [
         "@types/react",
         "react",
@@ -172,8 +172,8 @@
     "@standard-schema/spec@1.0.0": {
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
     },
-    "@types/react@19.2.7": {
-      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+    "@types/react@19.2.5": {
+      "integrity": "sha512-keKxkZMqnDicuvFoJbzrhbtdLSPhj/rZThDlKWCDbgXmUg0rEUFtRssDXKYmtXluZlIqiC5VqkCgRwzuyLHKHw==",
       "dependencies": [
         "csstype"
       ]
@@ -263,8 +263,8 @@
     "empathic@2.0.0": {
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="
     },
-    "exsolve@1.0.8": {
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="
+    "exsolve@1.0.7": {
+      "integrity": "sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw=="
     },
     "fast-check@3.23.2": {
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
@@ -400,8 +400,8 @@
     "postgres@3.4.7": {
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="
     },
-    "prisma@7.1.0-dev.10": {
-      "integrity": "sha512-XdSkAdxVbV+5dwqBdT3102ANSkFkCWp14UKHcZb64tEXTMwDg3b1mwTIe2+eLAS0YAigRoiczQqPs4S5C3m0WQ==",
+    "prisma@7.1.0-dev.15": {
+      "integrity": "sha512-ztqtIOfCcLyfgWX8rFAQcanLoDqrZNOgMvQAmP0tWS38xTbX52OsxweThDhIgUaXhySK3q8rErGhPE/QA+xxZw==",
       "dependencies": [
         "@prisma/config",
         "@prisma/dev",
@@ -486,8 +486,8 @@
     "std-env@3.9.0": {
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
     },
-    "tinyexec@1.0.2": {
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="
+    "tinyexec@1.0.1": {
+      "integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="
     },
     "type-fest@4.41.0": {
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
@@ -512,9 +512,9 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.12",
-      "npm:@prisma/client@7.1.0-dev.10",
+      "npm:@prisma/client@7.1.0-dev.15",
       "npm:@prisma/extension-accelerate@1.2.2",
-      "npm:prisma@7.1.0-dev.10"
+      "npm:prisma@7.1.0-dev.15"
     ]
   }
 }

--- a/runtimes/deno/deno.lock
+++ b/runtimes/deno/deno.lock
@@ -4,10 +4,10 @@
     "jsr:@std/assert@*": "1.0.12",
     "jsr:@std/assert@^1.0.12": "1.0.12",
     "jsr:@std/internal@^1.0.6": "1.0.6",
-    "npm:@prisma/adapter-pg@6.19.0-integration-next.21": "6.19.0-integration-next.21",
-    "npm:@prisma/client@6.19.0-integration-next.21": "6.19.0-integration-next.21_prisma@6.19.0-integration-next.21",
+    "npm:@prisma/adapter-pg@7.1.0-dev.15": "7.1.0-dev.15",
+    "npm:@prisma/client@7.1.0-dev.15": "7.1.0-dev.15_prisma@7.1.0-dev.15",
     "npm:@types/node@*": "22.12.0",
-    "npm:prisma@6.19.0-integration-next.21": "6.19.0-integration-next.21"
+    "npm:prisma@7.1.0-dev.15": "7.1.0-dev.15"
   },
   "jsr": {
     "@std/assert@1.0.12": {
@@ -21,19 +21,69 @@
     }
   },
   "npm": {
-    "@prisma/adapter-pg@6.19.0-integration-next.21": {
-      "integrity": "sha512-Sx0xNAsCC7prd09/VbqQnEsNfbRmM6jOtTZY0G6zg9qwKhIDNxfSZHdRR5PFnRPeLkZTp/tEbHWZTAK9mhjAtg==",
+    "@chevrotain/cst-dts-gen@10.5.0": {
+      "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
+      "dependencies": [
+        "@chevrotain/gast",
+        "@chevrotain/types",
+        "lodash"
+      ]
+    },
+    "@chevrotain/gast@10.5.0": {
+      "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
+      "dependencies": [
+        "@chevrotain/types",
+        "lodash"
+      ]
+    },
+    "@chevrotain/types@10.5.0": {
+      "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="
+    },
+    "@chevrotain/utils@10.5.0": {
+      "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="
+    },
+    "@electric-sql/pglite-socket@0.0.6_@electric-sql+pglite@0.3.2": {
+      "integrity": "sha512-6RjmgzphIHIBA4NrMGJsjNWK4pu+bCWJlEWlwcxFTVY3WT86dFpKwbZaGWZV6C5Rd7sCk1Z0CI76QEfukLAUXw==",
+      "dependencies": [
+        "@electric-sql/pglite"
+      ],
+      "bin": true
+    },
+    "@electric-sql/pglite-tools@0.2.7_@electric-sql+pglite@0.3.2": {
+      "integrity": "sha512-9dAccClqxx4cZB+Ar9B+FZ5WgxDc/Xvl9DPrTWv+dYTf0YNubLzi4wHHRGRGhrJv15XwnyKcGOZAP1VXSneSUg==",
+      "dependencies": [
+        "@electric-sql/pglite"
+      ]
+    },
+    "@electric-sql/pglite@0.3.2": {
+      "integrity": "sha512-zfWWa+V2ViDCY/cmUfRqeWY1yLto+EpxjXnZzenB1TyxsTiXaTWeZFIZw6mac52BsuQm0RjCnisjBtdBaXOI6w=="
+    },
+    "@hono/node-server@1.14.2_hono@4.7.10": {
+      "integrity": "sha512-GHjpOeHYbr9d1vkID2sNUYkl5IxumyhDrUJB7wBp7jvqYwPFt+oNKsAPBRcdSbV7kIrXhouLE199ks1QcK4r7A==",
+      "dependencies": [
+        "hono"
+      ]
+    },
+    "@mrleebo/prisma-ast@0.12.1": {
+      "integrity": "sha512-JwqeCQ1U3fvccttHZq7Tk0m/TMC6WcFAQZdukypW3AzlJYKYTGNVd1ANU2GuhKnv4UQuOFj3oAl0LLG/gxFN1w==",
+      "dependencies": [
+        "chevrotain",
+        "lilconfig"
+      ]
+    },
+    "@prisma/adapter-pg@7.1.0-dev.15": {
+      "integrity": "sha512-MbIwoOJuHQ0bpJqi5+Rv3OnmXo1roTSPFpjTYIkoYCoFSNoJJaRyTfCb00+iXAmcRlI2RGEQZ93ypgKo/BlKjw==",
       "dependencies": [
         "@prisma/driver-adapter-utils",
         "pg",
         "postgres-array@3.0.4"
       ]
     },
-    "@prisma/client-runtime-utils@6.19.0-integration-next.21": {
-      "integrity": "sha512-/GuOho+spq6AR7Sin5hi9wMlqqDGkxQGhlv6CTq/8eNnsX2DGCCawar167o2FtvMfJxwf+MeWD0dvp/wiS5f7w=="
+    "@prisma/client-runtime-utils@7.1.0-dev.15": {
+      "integrity": "sha512-H2Dmnn3pGrWpw7O56gIB3d9zTSXu9EZ50DljNXt0r4XNe//eM4kOEdipak6FGnxjPa30NXFOQEwaRXkhVRJHSA=="
     },
-    "@prisma/client@6.19.0-integration-next.21_prisma@6.19.0-integration-next.21": {
-      "integrity": "sha512-sqe0jTUFWAnfx1mA42FmLU6LP3lRxo5ABvDSlyqMiXxnYZtpQ0H8AA7KYAo5rkyFP5wSepZUtxptqL4T32mHdA==",
+    "@prisma/client@7.1.0-dev.15_prisma@7.1.0-dev.15": {
+      "integrity": "sha512-6WNRbSwiI/WCSfWSvXHIpwdHOE76Py6Rzdm69vDgXA7IWy0p0vpvEar3gvozdjkaorBf+t9nMVN65qO2wWbxwg==",
       "dependencies": [
         "@prisma/client-runtime-utils",
         "prisma"
@@ -42,8 +92,8 @@
         "prisma"
       ]
     },
-    "@prisma/config@6.19.0-integration-next.21": {
-      "integrity": "sha512-sO0wAIseGl/rPedIfughTHJOmoTs3/9zO2Ngn3CvTjgZzz4xRL0uW+RYgBFGVDFYvyRM3GTor3JKTufo94TGlQ==",
+    "@prisma/config@7.1.0-dev.15": {
+      "integrity": "sha512-d0DBR83jafQwwFBSalYIf9W6WTpTYhIdePjU5HA/VX22vmc0aGFuIhS+6JNjaTNvV9XedmVLSlkjboNMVlbvIw==",
       "dependencies": [
         "c12",
         "deepmerge-ts",
@@ -51,20 +101,14 @@
         "empathic"
       ]
     },
-    "@prisma/debug@6.19.0-integration-next.21": {
-      "integrity": "sha512-4CIzPeADZ2R2WFu2RZH6dzEpEehSbjXJYWYKm5NUkEugGWodrwwy2D7P0gH926pY7ExaN2h35Pfd9D5wV3hU/g=="
+    "@prisma/debug@6.8.2": {
+      "integrity": "sha512-4muBSSUwJJ9BYth5N8tqts8JtiLT8QI/RSAzEogwEfpbYGFo9mYsInsVo8dqXdPO2+Rm5OG5q0qWDDE3nyUbVg=="
     },
-    "@prisma/driver-adapter-utils@6.19.0-integration-next.21": {
-      "integrity": "sha512-tas14qPXiqHlY3JTaUQVf3axphBgyJas+3EuvapqnsU70Hjp33xpG/ZxBiD7+c0i/QokoIDW/Jvi9toj7Zf1zQ==",
-      "dependencies": [
-        "@prisma/debug"
-      ]
+    "@prisma/debug@7.1.0-dev.15": {
+      "integrity": "sha512-9gVVHLJTxSQ8l8iWL0/jRvtmIQqLKhfUsuFC/e4EXBxZKkxLdbNqgXSuLOwvO1Fv3m7W2QMGzlGg6QGpw2z/jA=="
     },
-    "@prisma/engines-version@6.19.0-31.next-6f525e2b254a97a9c547ae5f2b29c54a171f6b23": {
-      "integrity": "sha512-WVSCTe947lyxnIh+IaE0CRgZvCalcNP+JmG25980ApCu9VWKp+InXZ35pyR6mbyK4vEWA5jPjyhaIepGn5V2Vw=="
-    },
-    "@prisma/engines@6.19.0-integration-next.21": {
-      "integrity": "sha512-s/fJuzT04iayvjJ7jb/1tOAsSdFgeacnd/SY9RAwAWBX8qKZ72zwEwXxYc5jnXVrHbSMa4dG3cWi/AOsGhpcRQ==",
+    "@prisma/dev@0.13.0_@electric-sql+pglite@0.3.2_hono@4.7.10": {
+      "integrity": "sha512-QMmF6zFeUF78yv1HYbHvod83AQnl7u6NtKyDhTRZOJup3h1icWs8R7RUVxBJZvM2tBXNAMpLQYYM/8kPlOPegA==",
       "dependencies": [
         "@electric-sql/pglite",
         "@electric-sql/pglite-socket",
@@ -85,37 +129,43 @@
         "zeptomatch"
       ]
     },
-    "@prisma/engines-version@7.1.0-4.671452b04ff2b1a300f34311d53ac29cc925e1a7": {
-      "integrity": "sha512-Q2mjAZTZ+98Ym3a1T2Fm+RlBW2v7MPIMa4QzDQNmFXHDZJB3Uz70XrP9zZ+31C+urp4AVicjzGmwpYX5y3utSQ=="
-    },
-    "@prisma/engines@7.1.0-dev.16": {
-      "integrity": "sha512-HkkitesaWFynZf+RqHeDnjwY40BEOrd12nt65o7JcCKjMnxGIuylSeLc9Q5/kNltzNN4k+SlOI0p7l1z0RmpMg==",
+    "@prisma/driver-adapter-utils@7.1.0-dev.15": {
+      "integrity": "sha512-mPsVAFW2NxYVJLNuJ/CukbgpQydpvw+KFz42ESbWDrDVnH+4rboEmU+QDha9cWAO8WYbyMpcYar4f4Ti89nK9g==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16",
+        "@prisma/debug@7.1.0-dev.15"
+      ]
+    },
+    "@prisma/engines-version@7.1.0-3.d9cee0d5892b6ac19222fb0ef2384cc3d5efd043": {
+      "integrity": "sha512-gDWKrBS1Urw6gX5lzKvzu3md3zVqRvZLFExzfEGBVy9Y0vKwd4tQHSv3rcVwVK1WUaNjIhLTIHscgMkULi1soQ=="
+    },
+    "@prisma/engines@7.1.0-dev.15": {
+      "integrity": "sha512-+hMy8d9FuRWkYX3fyy6huQ0E5n9da1uftoYXtG8ZUWM+T+8D0kMf7lUBxCiTTmxxrR9ZLktWWc+vrrQbi/o39w==",
+      "dependencies": [
+        "@prisma/debug@7.1.0-dev.15",
         "@prisma/engines-version",
         "@prisma/fetch-engine",
-        "@prisma/get-platform@7.1.0-dev.16"
+        "@prisma/get-platform@7.1.0-dev.15"
       ],
       "scripts": true
     },
-    "@prisma/fetch-engine@6.19.0-integration-next.21": {
-      "integrity": "sha512-QWHT0R6DrYEWUWC8iTMIEkVKEGq8g3BkGTc1nBnuGU0hHqNrga917G2TE0IR/ZRC2GSSbS2onUxTO+wydiiVxQ==",
+    "@prisma/fetch-engine@7.1.0-dev.15": {
+      "integrity": "sha512-dfEr/yC19U8WARZYl0MLG8wjs4NWGmWgVTcNZv+MCBjoNUkJZd7NLgxAdyXAdExoRvIj5m1jFdWdiMivVfvv2g==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16",
+        "@prisma/debug@7.1.0-dev.15",
         "@prisma/engines-version",
-        "@prisma/get-platform@7.1.0-dev.16"
+        "@prisma/get-platform@7.1.0-dev.15"
       ]
     },
-    "@prisma/get-platform@6.19.0-integration-next.21": {
-      "integrity": "sha512-vg4otESoPhkbJNJuPthPQ475zaW5An4iSsOgt0kw+CDI3DsAuGArAN+V2apcvkIRg/ujpGDdXARMRJqrduiqyw==",
+    "@prisma/get-platform@6.8.2": {
+      "integrity": "sha512-vXSxyUgX3vm1Q70QwzwkjeYfRryIvKno1SXbIqwSptKwqKzskINnDUcx85oX+ys6ooN2ATGSD0xN2UTfg6Zcow==",
       "dependencies": [
         "@prisma/debug@6.8.2"
       ]
     },
-    "@prisma/get-platform@7.1.0-dev.16": {
-      "integrity": "sha512-0vvBkSSj5ikC6oTXF8PGUSfzZ9dEJX+VSS65Y5QVtp5z5qsxR2dGm/bCo91Qwid2+F3NUYCSbGt07MaAB3L+rg==",
+    "@prisma/get-platform@7.1.0-dev.15": {
+      "integrity": "sha512-GANk5MgyF71LyD/vbRlCOuCm2OG56JVrYfFi6/dMcuw2XCFdN+/wSlqSKJRHValh5/Azg4so7ZMfFqRJIPU4Lg==",
       "dependencies": [
-        "@prisma/debug@7.1.0-dev.16"
+        "@prisma/debug@7.1.0-dev.15"
       ]
     },
     "@prisma/query-plan-executor@6.18.0": {
@@ -237,6 +287,22 @@
       "dependencies": [
         "pure-rand"
       ]
+    },
+    "foreground-child@3.3.1": {
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dependencies": [
+        "cross-spawn",
+        "signal-exit@4.1.0"
+      ]
+    },
+    "generate-function@2.3.1": {
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": [
+        "is-property"
+      ]
+    },
+    "get-port-please@3.1.2": {
+      "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
     },
     "giget@2.0.0": {
       "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
@@ -412,8 +478,11 @@
         "xtend"
       ]
     },
-    "prisma@6.19.0-integration-next.21": {
-      "integrity": "sha512-zXYuEK52uNWjzfYNrMxTH8tNNdo6gezOwPWe/+cu6sCKlpKjim+A6kYcs8PBdvMtNAA3CPbBNVzqOznKCfIeew==",
+    "postgres@3.4.7": {
+      "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw=="
+    },
+    "prisma@7.1.0-dev.15": {
+      "integrity": "sha512-ztqtIOfCcLyfgWX8rFAQcanLoDqrZNOgMvQAmP0tWS38xTbX52OsxweThDhIgUaXhySK3q8rErGhPE/QA+xxZw==",
       "dependencies": [
         "@prisma/config",
         "@prisma/dev",
@@ -456,25 +525,86 @@
     "readdirp@4.1.2": {
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="
     },
+    "regexp-to-ast@0.5.0": {
+      "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="
+    },
+    "remeda@2.21.3": {
+      "integrity": "sha512-XXrZdLA10oEOQhLLzEJEiFFSKi21REGAkHdImIb4rt/XXy8ORGXh5HCcpUOsElfPNDb+X6TA/+wkh+p2KffYmg==",
+      "dependencies": [
+        "type-fest"
+      ]
+    },
+    "retry@0.12.0": {
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="
+    },
+    "safer-buffer@2.1.2": {
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "scheduler@0.27.0": {
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "seq-queue@0.0.5": {
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
+    },
+    "shebang-command@2.0.0": {
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dependencies": [
+        "shebang-regex"
+      ]
+    },
+    "shebang-regex@3.0.0": {
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+    },
+    "signal-exit@3.0.7": {
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "signal-exit@4.1.0": {
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+    },
     "split2@4.2.0": {
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
+    "sqlstring@2.3.3": {
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
+    },
+    "std-env@3.9.0": {
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw=="
     },
     "tinyexec@1.0.2": {
       "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="
     },
+    "type-fest@4.41.0": {
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+    },
     "undici-types@6.20.0": {
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
     },
+    "valibot@1.1.0": {
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw=="
+    },
+    "which@2.0.2": {
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dependencies": [
+        "isexe"
+      ],
+      "bin": true
+    },
     "xtend@4.0.2": {
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "zeptomatch@2.0.2": {
+      "integrity": "sha512-H33jtSKf8Ijtb5BW6wua3G5DhnFjbFML36eFu+VdOoVY4HD9e7ggjqdM6639B+L87rjnR6Y+XeRzBXZdy52B/g==",
+      "dependencies": [
+        "grammex"
+      ]
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.12",
-      "npm:@prisma/adapter-pg@6.19.0-integration-next.21",
-      "npm:@prisma/client@6.19.0-integration-next.21",
-      "npm:prisma@6.19.0-integration-next.21"
+      "npm:@prisma/adapter-pg@7.1.0-dev.15",
+      "npm:@prisma/client@7.1.0-dev.15",
+      "npm:prisma@7.1.0-dev.15"
     ]
   }
 }


### PR DESCRIPTION
Something in the lockfiles is causing weird errors in both tests and [the version update job.](https://github.com/prisma/ecosystem-tests/actions/runs/19697849106/job/56426877257) I reverted the state of the two lockfiles to what they were before the Prisma 7 fix PR landed.

Fixed [accelerate (deno, <accelerate>, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/19698327410/job/56428256478?pr=5985#logs).
[runtimes (deno, client, ubuntu-22.04)](https://github.com/prisma/ecosystem-tests/actions/runs/19698327410/job/56428256524?pr=5985#logs) is still broken for some unrelated reason (our connection URL fails authentication with the pg adapter).

This should also fix the check-for-updates job.