### PR TITLE
chore: bump to node 22

### DIFF
--- a/driver-adapters/neon-http-lambda-basic/run.sh
+++ b/driver-adapters/neon-http-lambda-basic/run.sh
@@ -23,5 +23,5 @@ fi
 cp "$GENERATED_CLIENT/schema.prisma" dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-neon-http-lambda-basic --runtime nodejs20.x --environment "Variables={DRIVER_ADAPTERS_NEON_HTTP_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_NEON_HTTP_LAMBDA_BASIC_DATABASE_URL}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-neon-http-lambda-basic --runtime nodejs22.x --environment "Variables={DRIVER_ADAPTERS_NEON_HTTP_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_NEON_HTTP_LAMBDA_BASIC_DATABASE_URL}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-neon-http-lambda-basic --zip-file "fileb://lambda.zip"

--- a/driver-adapters/neon-lambda-basic/run.sh
+++ b/driver-adapters/neon-lambda-basic/run.sh
@@ -23,5 +23,5 @@ fi
 cp "$GENERATED_CLIENT/schema.prisma" dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-neon-lambda-basic --runtime nodejs20.x --environment "Variables={DRIVER_ADAPTERS_NEON_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_NEON_LAMBDA_BASIC_DATABASE_URL}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-neon-lambda-basic --runtime nodejs22.x --environment "Variables={DRIVER_ADAPTERS_NEON_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_NEON_LAMBDA_BASIC_DATABASE_URL}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-neon-lambda-basic --zip-file "fileb://lambda.zip"

--- a/driver-adapters/pg-lambda-basic/run.sh
+++ b/driver-adapters/pg-lambda-basic/run.sh
@@ -23,5 +23,5 @@ fi
 cp "$GENERATED_CLIENT/schema.prisma" dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-pg-lambda-basic --runtime nodejs20.x --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-pg-lambda-basic --runtime nodejs22.x --environment "Variables={DATABASE_URL=$DATABASE_URL}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-pg-lambda-basic --zip-file "fileb://lambda.zip"

--- a/driver-adapters/planetscale-lambda-basic/run.sh
+++ b/driver-adapters/planetscale-lambda-basic/run.sh
@@ -23,5 +23,5 @@ fi
 cp "$GENERATED_CLIENT/schema.prisma" dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-planetscale-lambda-basic --runtime nodejs20.x --environment "Variables={DATABASE_URL_PLANETSCALE=$DATABASE_URL_PLANETSCALE}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-planetscale-lambda-basic --runtime nodejs22.x --environment "Variables={DATABASE_URL_PLANETSCALE=$DATABASE_URL_PLANETSCALE}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-planetscale-lambda-basic --zip-file "fileb://lambda.zip"

--- a/driver-adapters/turso-web-lambda-basic/run.sh
+++ b/driver-adapters/turso-web-lambda-basic/run.sh
@@ -23,5 +23,5 @@ fi
 cp "$GENERATED_CLIENT/schema.prisma" dist
 zip -rj lambda.zip dist
 
-aws lambda update-function-configuration --function-name driver-adapters-turso-lambda-basic --runtime nodejs20.x --environment "Variables={DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL,DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN}" --timeout 30
+aws lambda update-function-configuration --function-name driver-adapters-turso-lambda-basic --runtime nodejs22.x --environment "Variables={DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_DATABASE_URL,DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN=$DRIVER_ADAPTERS_TURSO_LAMBDA_BASIC_TOKEN}" --timeout 30
 aws lambda update-function-code --function-name driver-adapters-turso-lambda-basic --zip-file "fileb://lambda.zip"

--- a/platforms-serverless/gcp-functions/run.sh
+++ b/platforms-serverless/gcp-functions/run.sh
@@ -12,4 +12,4 @@ npx tsc
 func="e2e-test-$(date "+%Y-%m-%d-%H%M%S")"
 echo "$func" > func-tmp.txt
 
-gcloud functions deploy "$func" --runtime nodejs20 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms azure functions linux gcp functions env'
+gcloud functions deploy "$func" --runtime nodejs22 --trigger-http --entry-point=handler --allow-unauthenticated --verbosity debug --set-env-vars DATABASE_URL=$DATABASE_URL,PRISMA_TELEMETRY_INFORMATION='ecosystem-tests platforms azure functions linux gcp functions env'

--- a/platforms-serverless/lambda-node-20/run.sh
+++ b/platforms-serverless/lambda-node-20/run.sh
@@ -16,7 +16,7 @@ rm -rf lambda.zip
 zip --symlinks -r lambda.zip index.js prisma/schema.prisma node_modules/@prisma/* node_modules/.pnpm/{@prisma,pg,postgres,xtend,split2}*
 du -b ./lambda.zip
 
-AWS_RUNTIME=nodejs20.x
+AWS_RUNTIME=nodejs22.x
 AWS_RUNTIME_VERSION=20
 
 # https://docs.aws.amazon.com/cli/latest/reference/lambda/

--- a/platforms-serverless/serverless-framework-lambda/serverless.yml
+++ b/platforms-serverless/serverless-framework-lambda/serverless.yml
@@ -2,7 +2,7 @@ service: platforms-serverless-slsf-library
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
   memorySize: 512
   timeout: 10
   versionFunctions: false


### PR DESCRIPTION
[TML-1613](https://linear.app/prisma-company/issue/TML-1613/aws-lambda-nodejs-20x-end-of-life-april-2026)

The failing tests are already broken on `dev`.