### PR TITLE
chore: remove security.md in favor of .github

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,0 @@
-# Security Policy
-
-If you have a security issue to report, please contact us at [security@prisma.io](mailto:security@prisma.io).


### PR DESCRIPTION
Remove SECURITY.md from this repository in favor of the prisma/.github/SECURITY.md which will get inherited.