### PR TITLE
chore: run functions:secrets:set with --force to replace old versions

### DIFF
--- a/platforms-serverless/firebase-functions/run.sh
+++ b/platforms-serverless/firebase-functions/run.sh
@@ -11,6 +11,6 @@ echo "$FIREBASE_PRIVATE_KEY" > "./privateKey.json"
 cd functions/ && sh prepare_in_project.sh "$func" && cd ..
 
 echo "$DATABASE_URL" > db_credentials.txt
-GOOGLE_APPLICATION_CREDENTIALS="./privateKey.json" pnpm firebase functions:secrets:set PRISMA_DB --data-file db_credentials.txt
+GOOGLE_APPLICATION_CREDENTIALS="./privateKey.json" pnpm firebase functions:secrets:set PRISMA_DB --data-file db_credentials.txt --force
 
 GOOGLE_APPLICATION_CREDENTIALS="./privateKey.json" pnpm firebase deploy --only "functions:firebase-functions:$func"


### PR DESCRIPTION
When running `functions:secrets:set` with `--force` the CLI should update the affected functions and disable old secret version. This should save us some GCP costs, since disabled secrets cost nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Firebase deployment script for more reliable secret configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->